### PR TITLE
Add "removeConsent" cmd to client API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "consent-management-provider",
-  "version": "2.1.4",
+  "version": "2.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "consent-management-provider",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "A minimal consent manager aiming for compliance to IAB's Transperancy and Consent Framework (TCF v2) ",
   "main": "dist/app.js",
   "scripts": {

--- a/templates/mini-cmp.ejs
+++ b/templates/mini-cmp.ejs
@@ -80,6 +80,14 @@ window.__tcfapi = function(command, version, callback, parameter) {
         localStorage.setItem('<%-COOKIE_NAME%>', parameter);
       }
       break;
+    case 'removeConsent':
+      var i = document.createElement('img');
+      i.setAttribute('src', '<%-URL_SCHEME%>://<%-CONSENT_SERVER_HOST%>/remove-consent');
+      if (window.localStorage && localStorage.removeItem) {
+        localStorage.removeItem('<%-COOKIE_NAME%>');
+      }
+      callback();
+      break;
     <%-BANNER_NO_IFRAME%>
     default:
       break;


### PR DESCRIPTION
Removes stored consent in localStorage and cookie. Useful for e.g. debugging.