### PR TITLE
ES3 compatibility improvements

### DIFF
--- a/src/templates/banner.js
+++ b/src/templates/banner.js
@@ -82,7 +82,7 @@ window.__cbapi = function (command, version, callback, parameter) {
     if (!element) {
       return;
     }
-    element.classList.add('selected');
+    element.className = element.className.length ? element.className + ' selected' : 'selected';
     element.style.color = '#ffffff';
     element.style.backgroundColor = '#76b642';
   }
@@ -91,13 +91,13 @@ window.__cbapi = function (command, version, callback, parameter) {
     if (!element) {
       return;
     }
-    element.classList.remove('selected');
+    element.className = element.className.replace('selected', '');
     element.style.color = '#76b642';
     element.style.backgroundColor = '#ffffff';
   }
 
   function handleSelectionToggle() {
-    if (consBtnAgree && !consBtnAgree.classList.contains('selected')) {
+    if (consBtnAgree && consBtnAgree.className.indexOf('selected') == -1) {
       setSelected(consBtnAgree);
       setNotSelected(consBtnDismiss);
     } else {
@@ -107,7 +107,7 @@ window.__cbapi = function (command, version, callback, parameter) {
   }
 
   function handleEnter() {
-    if (consBtnAgree && consBtnAgree.classList.contains('selected')) {
+    if (consBtnAgree && consBtnAgree.className.indexOf('selected') != -1) {
       !!setConsentCallback && setConsentCallback(true);
     } else {
       !!setConsentCallback && setConsentCallback(false);

--- a/src/templates/banner.js
+++ b/src/templates/banner.js
@@ -91,7 +91,7 @@ window.__cbapi = function (command, version, callback, parameter) {
     if (!element) {
       return;
     }
-    element.className = element.className.replace('selected', '');
+    element.className = element.className.replace(/selected/g, '');
     element.style.color = '#76b642';
     element.style.backgroundColor = '#ffffff';
   }

--- a/src/templates/banner.js
+++ b/src/templates/banner.js
@@ -120,7 +120,7 @@ window.__cbapi = function (command, version, callback, parameter) {
   }
 
   function handleVK(parameter) {
-    if (!isConsentBannerVisible) {
+    if (!isConsentBannerVisible()) {
       return;
     }
 

--- a/src/templates/cmp.js
+++ b/src/templates/cmp.js
@@ -3,11 +3,11 @@
   var logEntries = [];
 
   window.__tcfapi = function (command, version, callback, parameter) {
-    queue[queue.length] = Array.prototype.slice.call(arguments);
+    queue[queue.length] = Array.prototype.slice.call(arguments, 0);
   };
 
   window.__tcfapi('onLogEvent', 2, function () {
-    logEntries[logEntries.length] = Array.prototype.slice.call(arguments);
+    logEntries[logEntries.length] = Array.prototype.slice.call(arguments, 0);
   });
 
   var channelId = '<%-CHANNEL_ID%>';
@@ -33,7 +33,7 @@
     if (!queue) return;
     for (var i = 0; i < queue.length; i++) {
       var f = queue[i];
-      window.__tcfapi.apply(null, f.slice());
+      window.__tcfapi.apply(null, f.slice(0));
     }
     delete queue;
   }


### PR DESCRIPTION
The following fixes are included
- `classList` DOM manipulation is replaced by using `className` directly
- `Array.prototype.slice()` in older specifications required the `start` parameter (https://es5.github.io/x15.4.html#x15.4.4.10)
- banner key handling: banner visibility check fixed