### PR TITLE
Extended iframe exclusion list

### DIFF
--- a/src/templates/cmp.js
+++ b/src/templates/cmp.js
@@ -67,9 +67,9 @@
 
   function isIframeCapable() {
     var excludeList = ['hybrid', 'presto', 'maple', 'smarttv2012', 'antgalio', 'technotrend goerler', 'viera 2013'];
-    var currentUserAgent = window.navigator && navigator.userAgent.toLowerCase();
+    var currentUserAgent = window.navigator && navigator.userAgent && navigator.userAgent.toLowerCase();
 
-    if (!currentUserAgent) {
+    if (!currentUserAgent || !currentUserAgent.indexOf) {
       return false;
     }
 

--- a/src/templates/cmp.js
+++ b/src/templates/cmp.js
@@ -66,12 +66,19 @@
   }
 
   function isIframeCapable() {
-    return (
-      window.navigator &&
-      navigator.userAgent &&
-      navigator.userAgent.indexOf &&
-      navigator.userAgent.indexOf('Presto') === -1
-    );
+    var excludeList = ['hybrid', 'presto', 'maple', 'smarttv2012', 'antgalio', 'technotrend goerler', 'viera 2013'];
+    var currentUserAgent = window.navigator && navigator.userAgent.toLowerCase();
+
+    if (!currentUserAgent) {
+      return false;
+    }
+
+    var userAgentIsExcluded = false;
+    for (var i = 0; i < excludeList.length; i++) {
+      userAgentIsExcluded = userAgentIsExcluded || currentUserAgent.indexOf(excludeList[i]) !== -1;
+    }
+
+    return !userAgentIsExcluded;
   }
 
   function createIframe() {

--- a/src/templates/cmp.js
+++ b/src/templates/cmp.js
@@ -66,17 +66,7 @@
   }
 
   function isIframeCapable() {
-    var excludeList = [
-      'antgalio',
-      'hybrid',
-      'maple',
-      'presto',
-      'smarttv2012',
-      'technotrend goerler',
-      'viera 2011',
-      'viera 2012',
-      'viera 2013',
-    ];
+    var excludeList = ['antgalio', 'hybrid', 'maple', 'presto', 'technotrend goerler', 'viera 2011'];
     var currentUserAgent = window.navigator && navigator.userAgent && navigator.userAgent.toLowerCase();
 
     if (!currentUserAgent || !currentUserAgent.indexOf) {

--- a/src/templates/cmp.js
+++ b/src/templates/cmp.js
@@ -67,10 +67,11 @@
 
   function isIframeCapable() {
     var excludeList = [
-      'hybrid',
-      'presto',
-      'maple',
       'antgalio',
+      'hybrid',
+      'maple',
+      'presto',
+      'smarttv2012',
       'technotrend goerler',
       'viera 2011',
       'viera 2012',

--- a/src/templates/cmp.js
+++ b/src/templates/cmp.js
@@ -66,7 +66,16 @@
   }
 
   function isIframeCapable() {
-    var excludeList = ['hybrid', 'presto', 'maple', 'smarttv2012', 'antgalio', 'technotrend goerler', 'viera 2013'];
+    var excludeList = [
+      'hybrid',
+      'presto',
+      'maple',
+      'antgalio',
+      'technotrend goerler',
+      'viera 2011',
+      'viera 2012',
+      'viera 2013',
+    ];
     var currentUserAgent = window.navigator && navigator.userAgent && navigator.userAgent.toLowerCase();
 
     if (!currentUserAgent || !currentUserAgent.indexOf) {


### PR DESCRIPTION
Currently only user agents containing `Presto` (Opera Browser) are excluded from iframe consent handling. The list of browser agents should be extended due to incompatibility with further browsers, like ANT Galio.