### PR TITLE
Banner callback on mount error

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ __cbapi(method, version, callback?, parameter?)
 
 | Method | Description  | Parameter | Callback  |
 |--------|--------------|------------|----------|
-| showBanner | displays a consent banner to the user | `string` (optional, id of the dom-node the banner should be rendered in. if not given, `document.body` is used) | `(consent: boolean) => void` |
+| showBanner | displays a consent banner to the user | `string` (optional, id of the dom-node the banner should be rendered in. if not given, `document.body` is used) | `(consent: boolean | undefined) => void` |
 | hideBanner | hides the consent banner | none | none |
 | isBannerVisible | Callback parameter shows if banner is currently shown | none | `(visible: boolean) => void`
 | handleKey | Allows for key handling of banner. Call for every key event after app called `showBanner` method. Do not use if app uses its own banner. The library does not add its own key handler and relies on the key handler of the host app. | `KeyboardEvent` | none |

--- a/src/templates/banner.js
+++ b/src/templates/banner.js
@@ -30,10 +30,10 @@ window.__cbapi = function (command, version, callback, parameter) {
     }
 
     if (!bannerParentNode) {
-      return;
+      return null;
     }
 
-    if (!document.getElementById('agttcnsntbnnr')) {
+    if (!document.getElementById('agttcnsntbnnr') && bannerParentNode.insertAdjacentHTML) {
       bannerParentNode.insertAdjacentHTML('beforeend', bannerContent);
     }
 
@@ -42,6 +42,7 @@ window.__cbapi = function (command, version, callback, parameter) {
 
   function showConsentBanner(nodeId, callback, retriesLeft) {
     if (retriesLeft < 0) {
+      callback(undefined);
       return;
     }
 


### PR DESCRIPTION
Currently the callback of `__cbapi`'s `showBanner` method is not called if the banner could not be injected into the DOM, even after 3 retries. This could lead to a state where the host application is waiting for the callback to execute and not forward key events to the banner.

This change executes the callback with a `undefined` consent status if the banner could not be injected (and therefore not displayed)