### PR TITLE
Use DOM api to build banner

### DIFF
--- a/src/templates/banner.js
+++ b/src/templates/banner.js
@@ -1,26 +1,115 @@
-var bannerContent =
-  '<div id="agttcnstbnnr" style="position:absolute; z-index:9999; left:20px; right:20px; bottom:20px; display:none; font-family:sans-serif; font-size:16px; font-weight:400; line-height:24px; color:#505050; background-color:#ffffff; border-radius:8px; border: 4px solid #76b642">' +
-  '<div style="margin: 30px 70px 0;"><span style="display:block; font-size:24px; line-height:24px; font-weight:500; color:#76b642; margin-bottom:16px">Datenschutzeinwilligung zur Reichweitenmessung</span>' +
-  '<span>Der Verein Arbeitsgemeinschaft Teletest (kurz AGTT, Details siehe agtt.at/hbb-Messung)<% if(!IS_PRO7){ %>, deren Mitglied <b><%-CHANNEL_NAME%></b> ist<%}%>, möchte ' +
-  'das Nutzungsverhalten der Zuseher:innen erfassen, um dadurch den Mitgliedern der AGTT die Möglichkeit zu geben, deren TV Angebot stetig verbessern zu können. Dazu benötigt die ' +
-  'AGTT Ihre Zustimmung, nach der ein Cookie auf Ihrem Gerät platziert wird, um folgende Informationen auslesen zu können:<br />' +
-  'Geräte ID, IP-Adresse, System- bzw. Browserinformationen, Geräteinformationen (verwendet HbbTV-Version, TV-Hersteller, Übertragungsweg via Satellit oder Kabel, Geräteauflösung). ' +
-  'Nähere Informationen zum Datenschutz finden Sie in der HbbTV Applikation des Senders, wo Sie den Status Ihrer Einwilligung verwalten bzw. ändern können.</span></div>' +
-  '<div style="color: #76b642; margin: 30px 70px 40px;">' +
-  '<span id="consBtnAgree" style="margin-right: 10px; padding: 10px; border: 1px solid #76b642; border-radius: 8px; background-color: #76b642; color: #ffffff" class="selected">Zustimmen</span>' +
-  '<span id="consBtnDismiss" style="margin-right: 10px; padding: 10px;border: 1px solid #76b642; border-radius: 8px; background-color: #ffffff; color: #76b642">Ablehnen</span>' +
-  '</div>' +
-  '</div>';
-
 var KeyEvent = window['KeyEvent'] || {};
 KeyEvent.VK_LEFT = KeyEvent.VK_LEFT || window['VK_LEFT'] || 37;
 KeyEvent.VK_RIGHT = KeyEvent.VK_RIGHT || window['VK_RIGHT'] || 39;
 KeyEvent.VK_ENTER = KeyEvent.VK_ENTER || window['VK_ENTER'] || 13;
 
 var consBtnAgree;
-var consBtnDismiss;
+var consBtnDecline;
 var setConsentCallback;
 var hideBannerTimeout;
+
+function buildBannerElement() {
+  var bannerOuter = document.createElement('div');
+  bannerOuter.id = 'agttcnstbnnr';
+  bannerOuter.style.position = 'absolute';
+  bannerOuter.style.left = '20px';
+  bannerOuter.style.right = '20px';
+  bannerOuter.style.bottom = '20px';
+  bannerOuter.style.display = 'none';
+  bannerOuter.style.fontFamily = 'sans-serif';
+  bannerOuter.style.fontSize = '16px';
+  bannerOuter.style.fontWeight = '400';
+  bannerOuter.style.lineHeight = '24px';
+  bannerOuter.style.color = '#505050';
+  bannerOuter.style.backgroundColor = '#ffffff';
+  bannerOuter.style.border = '4px solid #76b642';
+  bannerOuter.style.borderRadius = '8px';
+  bannerOuter.style.zIndex = '9999';
+
+  var bannerContentWrapper = document.createElement('div');
+  bannerContentWrapper.style.margin = '30px 70px 0 70px';
+
+  var bannerHeader = document.createElement('span');
+  bannerHeader.style.display = 'block';
+  bannerHeader.style.fontSize = '24px';
+  bannerHeader.style.lineHeight = '24px';
+  bannerHeader.style.fontWeight = '500';
+  bannerHeader.style.color = '#76b642';
+  bannerHeader.style.marginBottom = '16px';
+  bannerHeader.appendChild(document.createTextNode('Datenschutzeinwilligung zur Reichweitenmessung'));
+
+  var bannerLegalText = document.createElement('span');
+
+  if ('<%-IS_PRO7%>' === 'true') {
+    bannerLegalText.appendChild(
+      document.createTextNode(
+        'Der Verein Arbeitsgemeinschaft Teletest (kurz AGTT, Details siehe agtt.at/hbb-Messung), möchte ' +
+          'das Nutzungsverhalten der Zuseher:innen erfassen, um dadurch den Mitgliedern der AGTT die Möglichkeit zu geben, deren TV Angebot stetig verbessern zu können. Dazu benötigt die ' +
+          'AGTT Ihre Zustimmung, nach der ein Cookie auf Ihrem Gerät platziert wird, um folgende Informationen auslesen zu können:',
+      ),
+    );
+  } else {
+    var bannerLegalTextChannelName = document.createElement('b');
+    bannerLegalTextChannelName.appendChild(document.createTextNode('<%-CHANNEL_NAME%>'));
+
+    bannerLegalText.appendChild(
+      document.createTextNode(
+        'Der Verein Arbeitsgemeinschaft Teletest (kurz AGTT, Details siehe agtt.at/hbb-Messung), deren Mitglied ',
+      ),
+    );
+    bannerLegalText.appendChild(bannerLegalTextChannelName);
+    bannerLegalText.appendChild(
+      document.createTextNode(
+        ' ist, möchte ' +
+          'das Nutzungsverhalten der Zuseher:innen erfassen, um dadurch den Mitgliedern der AGTT die Möglichkeit zu geben, deren TV Angebot stetig verbessern zu können. Dazu benötigt die ' +
+          'AGTT Ihre Zustimmung, nach der ein Cookie auf Ihrem Gerät platziert wird, um folgende Informationen auslesen zu können:',
+      ),
+    );
+  }
+  bannerLegalText.appendChild(document.createElement('br'));
+  bannerLegalText.appendChild(
+    document.createTextNode(
+      'Geräte ID, IP-Adresse, System- bzw. Browserinformationen, Geräteinformationen (verwendet HbbTV-Version, TV-Hersteller, Übertragungsweg via Satellit oder Kabel, Geräteauflösung). ' +
+        'Nähere Informationen zum Datenschutz finden Sie in der HbbTV Applikation des Senders, wo Sie den Status Ihrer Einwilligung verwalten bzw. ändern können.',
+    ),
+  );
+
+  var bannerActionsWrapper = document.createElement('div');
+  bannerActionsWrapper.style.color = '#76b642';
+  bannerActionsWrapper.style.margin = '30px 70px 40px 70px';
+
+  var bannerActionAccept = document.createElement('span');
+  bannerActionAccept.id = 'consBtnAgree';
+  bannerActionAccept.className = 'selected';
+  bannerActionAccept.style.marginRight = '10px';
+  bannerActionAccept.style.padding = '10px';
+  bannerActionAccept.style.border = '1px solid #76b642';
+  bannerActionAccept.style.borderRadius = '8px';
+  bannerActionAccept.style.backgroundColor = '#76b642';
+  bannerActionAccept.style.color = '#ffffff';
+  bannerActionAccept.appendChild(document.createTextNode('Zustimmen'));
+
+  var bannerActionDecline = document.createElement('span');
+  bannerActionDecline.id = 'consBtnDecline';
+  bannerActionDecline.style.marginRight = '10px';
+  bannerActionDecline.style.padding = '10px';
+  bannerActionDecline.style.border = '1px solid #76b642';
+  bannerActionDecline.style.borderRadius = '8px';
+  bannerActionDecline.style.backgroundColor = '#ffffff';
+  bannerActionDecline.style.color = '#76b642';
+  bannerActionDecline.appendChild(document.createTextNode('Ablehnen'));
+
+  bannerActionsWrapper.appendChild(bannerActionAccept);
+  bannerActionsWrapper.appendChild(bannerActionDecline);
+
+  bannerContentWrapper.appendChild(bannerHeader);
+  bannerContentWrapper.appendChild(bannerLegalText);
+
+  bannerOuter.appendChild(bannerContentWrapper);
+  bannerOuter.appendChild(bannerActionsWrapper);
+
+  return bannerOuter;
+}
 
 window.__cbapi = function (command, version, callback, parameter) {
   function mountConsentBanner(nodeId) {
@@ -33,8 +122,8 @@ window.__cbapi = function (command, version, callback, parameter) {
       return null;
     }
 
-    if (!document.getElementById('agttcnstbnnr') && bannerParentNode.insertAdjacentHTML) {
-      bannerParentNode.insertAdjacentHTML('beforeend', bannerContent);
+    if (!document.getElementById('agttcnstbnnr')) {
+      bannerParentNode.appendChild(buildBannerElement());
     }
 
     return document.getElementById('agttcnstbnnr');
@@ -58,7 +147,7 @@ window.__cbapi = function (command, version, callback, parameter) {
     setConsentCallback = callback;
 
     consBtnAgree = document.getElementById('consBtnAgree');
-    consBtnDismiss = document.getElementById('consBtnDismiss');
+    consBtnDecline = document.getElementById('consBtnDecline');
 
     banner.style.display = 'block';
 
@@ -100,9 +189,9 @@ window.__cbapi = function (command, version, callback, parameter) {
   function handleSelectionToggle() {
     if (consBtnAgree && consBtnAgree.className.indexOf('selected') == -1) {
       setSelected(consBtnAgree);
-      setNotSelected(consBtnDismiss);
+      setNotSelected(consBtnDecline);
     } else {
-      setSelected(consBtnDismiss);
+      setSelected(consBtnDecline);
       setNotSelected(consBtnAgree);
     }
   }
@@ -117,7 +206,7 @@ window.__cbapi = function (command, version, callback, parameter) {
 
     // reset consent banner to have ACCEPT button selected
     setSelected(consBtnAgree);
-    setNotSelected(consBtnDismiss);
+    setNotSelected(consBtnDecline);
   }
 
   function handleVK(parameter) {


### PR DESCRIPTION
In order to not use `insertAdjacentHTML`, the banner is built using the DOM API.