### PR TITLE
Remove usage of atob/btoa

### DIFF
--- a/src/templates/cmp.js
+++ b/src/templates/cmp.js
@@ -56,13 +56,13 @@
     }
 
     var message =
-      callbackCount + ';' + type + ';' + command + ';' + version + ';' + btoa(JSON.stringify({ param: parameter }));
+      callbackCount + ';' + type + ';' + command + ';' + version + ';' + JSON.stringify({ param: parameter });
 
     iframe.contentWindow.postMessage(message, '<%-CONSENT_SERVER_PROTOCOL%>://<%-CONSENT_SERVER_HOST%>');
   }
 
   function log(event, success, parameters) {
-    window.__tcfapi('log', 2, function () {}, btoa(JSON.stringify({ event: event, parameters: parameters })));
+    window.__tcfapi('log', 2, function () {}, JSON.stringify({ event: event, parameters: parameters }));
   }
 
   function isIframeCapable() {
@@ -113,7 +113,7 @@
           var callback = callbackMap[id][position];
           if (logCallbackIndex + '' !== id) delete callbackMap[id];
           if (callback) {
-            var callbackParameter = JSON.parse(atob(message[++position]));
+            var callbackParameter = JSON.parse(message[++position]);
             callback(callbackParameter.param);
           }
         },

--- a/src/templates/iframe-msg.js
+++ b/src/templates/iframe-msg.js
@@ -14,12 +14,12 @@
           var id = message[0];
           var cmd = message[2];
           var version = message[3];
-          var param = JSON.parse(atob(message[4]));
+          var param = JSON.parse(message[4]);
           __tcfapi(
             cmd,
             version,
             function (cbParam) {
-              _message(id + ';' + btoa(JSON.stringify({ param: cbParam })));
+              _message(id + ';' + JSON.stringify({ param: cbParam }));
             },
             param.param,
           );

--- a/src/templates/tcfapi.js
+++ b/src/templates/tcfapi.js
@@ -130,7 +130,7 @@ window.__tcfapi = function (command, version, callback, parameter) {
       break;
     case 'log':
       if (parameter) {
-        var logParameters = JSON.parse(atob(parameter));
+        var logParameters = JSON.parse(parameter);
         if (logParameters && logParameters.event) {
           log(logParameters.event, true, logParameters.parameters);
         }


### PR DESCRIPTION
The methods `atob` and `btoa` should be removed due to possible incompatibilities with older HbbTV-devices/-standards.