### PR TITLE
Don't set banner zIndex if parent node id is given

### DIFF
--- a/index.ejs
+++ b/index.ejs
@@ -75,7 +75,6 @@
 </head>
 
 <body>
-  <div id='cmp'></div>
   <object id='video' type='video/broadcast' fullscreen='true' width='1280' height='720'
     style='position:absolute; top: 0px; left: 0px; width: 1280px; height: 720px;'></object>
   <div style='visibility: hidden; width: 0; height: 0; position: absolute;'>
@@ -83,6 +82,7 @@
     <object id='oipfCfg' type='application/oipfConfiguration'></object>
   </div>
   <script src='<%-BROWSER_REFRESH_URL%>'></script>
+  <div id='cmp'></div>
 </body>
 
 </html>

--- a/src/templates/banner.js
+++ b/src/templates/banner.js
@@ -24,7 +24,6 @@ function buildBannerElement() {
   bannerOuter.style.backgroundColor = '#ffffff';
   bannerOuter.style.border = '4px solid #76b642';
   bannerOuter.style.borderRadius = '8px';
-  bannerOuter.style.zIndex = '9999';
 
   var bannerContentWrapper = document.createElement('div');
   bannerContentWrapper.style.margin = '30px 70px 0 70px';
@@ -122,11 +121,18 @@ window.__cbapi = function (command, version, callback, parameter) {
       return null;
     }
 
-    if (!document.getElementById('agttcnstbnnr')) {
-      bannerParentNode.appendChild(buildBannerElement());
+    var banner = document.getElementById('agttcnstbnnr');
+
+    if (!banner) {
+      banner = buildBannerElement();
+      bannerParentNode.appendChild(banner);
     }
 
-    return document.getElementById('agttcnstbnnr');
+    if (!nodeId) {
+      banner.style.zIndex = '9999';
+    }
+
+    return banner;
   }
 
   function showConsentBanner(nodeId, callback, retriesLeft) {


### PR DESCRIPTION
If a parent node id for the banner is given, the visibility of this parent node is the responsibility of the host application. If no parent node id is given and the banner is mounted to the body, zIndex is set to `9999`.