### PR TITLE
Namespace change (__tcfapi --> __cmpapi)

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -6,9 +6,6 @@ on:
       - "feature/*"
       - "release/*"
       - "hotfix/*"
-    paths-ignore:
-      - "examples/**"
-      - "README.md"
 
 jobs:
   build-and-test:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,9 +5,6 @@ on:
       - "!develop"
     tags:
       - "v*.*.*"
-    paths-ignore:
-      - "examples/**"
-      - "README.md"
 
 jobs:
   build-and-push-image:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ opt-in/out ratio on a specific channel.
 - GET `/v2/cmp-with-tracking.js`- Returns a javascript bundle like `/cmp.js`, but also integrates the tracking script depending on the consent decision (<https://docs.tv-insight.com/tv-insight/integrate-hbbtv-v2-tracking-script>). There is one mandatory query param `cmpId` which has to be given (`4040`), the query parameters for the tracking script are passed through (see <https://docs.tv-insight.com/tv-insight/integrate-hbbtv-v2-tracking-script#tracking-script-parameters> for parameters)
 - GET `/v2/banner.js` - Returns the javascript bundle providing the `__cbapi()` API for controlling the consent banner.
 
-There is an alias for `__cmpapi` in order to maintain backwards compatibility with implementations still using `__tcfapi`. All methods available via `__cmpapi` are also availalbe via `__tcfapi`.
+There is an alias for `__cmpapi` in order to maintain backwards compatibility with implementations still using `__tcfapi`. All methods available via `__cmpapi` are also available via `__tcfapi`.
 
 ### __cmpapi methods
 

--- a/README.md
+++ b/README.md
@@ -24,17 +24,17 @@ Usage/Integration examples can be found in the `/examples` folder of this reposi
 All API endpoints take a query parameter`channelId`, which is used to collect metrics about the
 opt-in/out ratio on a specific channel.
 
-- GET `/v2/cmp.js` - Returns the javascript bundle providing the `__tcfapi()` API for client side checking of consent status.
+- GET `/v2/cmp.js` - Returns the javascript bundle providing the `__cmpapi()` API for client side checking of consent status.
 - GET `/v2/cmp-with-tracking.js`- Returns a javascript bundle like `/cmp.js`, but also integrates the tracking script depending on the consent decision (<https://docs.tv-insight.com/tv-insight/integrate-hbbtv-v2-tracking-script>). There is one mandatory query param `cmpId` which has to be given (`4040`), the query parameters for the tracking script are passed through (see <https://docs.tv-insight.com/tv-insight/integrate-hbbtv-v2-tracking-script#tracking-script-parameters> for parameters)
 - GET `/v2/banner.js` - Returns the javascript bundle providing the `__cbapi()` API for controlling the consent banner.
 
-### __tcfapi methods
+### __cmpapi methods
 
-Including the loader script into the application will expose the `window.__tcfapi()` method for client side checking of
-the consent status. The `__tcfapi` method has the following call signature:
+Including the loader script into the application will expose the `window.__cmpapi()` method for client side checking of
+the consent status. The `__cmpapi` method has the following call signature:
 
 ```js
-__tcfapi(method, version, callback?, parameter?)
+__cmpapi(method, version, callback?, parameter?)
 ```
 
 | Method | Description  | Parameter | Callback  |
@@ -84,7 +84,7 @@ type TCData = {
 
 ### Checking of consent status
 
-The `{HOST_URL}/v2/cmp.js` script can be added as javascript bundle to your application. This will expose the `__tcfapi()`
+The `{HOST_URL}/v2/cmp.js` script can be added as javascript bundle to your application. This will expose the `__cmpapi()`
 object on the window object providing access to consent information.
 
 The app needs to check `cmpStatus` and `consent` of the response of the `tcData` method. If `cmpStatus` is not set as
@@ -103,11 +103,11 @@ Add `cmp.js` bundle to your application:
 ```
 
 The `channelId` query parameter is optional and is used to collect metrics about which channel opt-ins/outs come from.
-Having added the `cmp.js` javascript file to the application, you can check for the user's consent status through the API endpoints provided by the `__tcfapi` object:
+Having added the `cmp.js` javascript file to the application, you can check for the user's consent status through the API endpoints provided by the `__cmpapi` object:
 
 ```js
 var CMP_VENDOR_ID = 4040; // custom vendor id to store AGTT-wide consent decision
-__tcfapi('getTCData', 2, function(tcData) {
+__cmpapi('getTCData', 2, function(tcData) {
   var isCmpEnabled = tcData.cmpStatus === 'loaded';
   if (!isCmpEnabled) {
     // do nothing, consent checking is unavailable
@@ -129,7 +129,7 @@ __tcfapi('getTCData', 2, function(tcData) {
 You can set the consent status for a user by executing to following API function:
 
 ```js
-__tcfapi('setConsent', 2, function() {
+__cmpapi('setConsent', 2, function() {
   // call returned successfully
 }, true); // set to false to revoke consent
 ```
@@ -142,7 +142,7 @@ By loading `/v2/banner.js` (besides `/v2/cmp.js`) an additional API is available
 <script src="{HOST_URL}/v2/banner.js?channelId=1234"></script>
 ```
 
-This will expose `window.__cbapi()`, which allows for controlling the display of a consent banner. The `__cbapi` method has the same call signature as `__tcfapi`:
+This will expose `window.__cbapi()`, which allows for controlling the display of a consent banner. The `__cbapi` method has the same call signature as `__cmpapi`:
 
 ```js
 __cbapi(method, version, callback?, parameter?)
@@ -168,7 +168,7 @@ var isShowingBanner = true;
 __cbapi('showBanner', 2, function(consent) {
   // user has closed the banner by remote control or the banner timeout was reached
   if (consentDecision === true || consentDecision === false) {
-    __tcfapi('setConsent', 2, undefined, consentDecision);
+    __cmpapi('setConsent', 2, undefined, consentDecision);
   }
   isShowingBanner = false;
 });

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ opt-in/out ratio on a specific channel.
 - GET `/v2/cmp-with-tracking.js`- Returns a javascript bundle like `/cmp.js`, but also integrates the tracking script depending on the consent decision (<https://docs.tv-insight.com/tv-insight/integrate-hbbtv-v2-tracking-script>). There is one mandatory query param `cmpId` which has to be given (`4040`), the query parameters for the tracking script are passed through (see <https://docs.tv-insight.com/tv-insight/integrate-hbbtv-v2-tracking-script#tracking-script-parameters> for parameters)
 - GET `/v2/banner.js` - Returns the javascript bundle providing the `__cbapi()` API for controlling the consent banner.
 
+There is an alias for `__cmpapi` in order to maintain backwards compatibility with implementations still using `__tcfapi`. All methods available via `__cmpapi` are also availalbe via `__tcfapi`.
+
 ### __cmpapi methods
 
 Including the loader script into the application will expose the `window.__cmpapi()` method for client side checking of

--- a/examples/consent-own-banner.html
+++ b/examples/consent-own-banner.html
@@ -10,7 +10,7 @@
     //<![CDATA[
     // example function for setting consent
     function setConsent(consent) {
-      window.__tcfapi('setConsent', 2, function (consent) {
+      window.__cmpapi('setConsent', 2, function (consent) {
         if (consent === true) {
           console.log("Consent given");
         } else if (consent === false) {
@@ -23,13 +23,13 @@
 
     // example function for removing consent decision
     function removeConsentDecision() {
-      window.__tcfapi('removeConsentDecision', 2, function () {
+      window.__cmpapi('removeConsentDecision', 2, function () {
         console.log("Consent decision removed")
       })
     }
 
     var CMP_VENDOR_ID = 4040;
-    window.__tcfapi('getTCData', 2, function (tcData) {
+    window.__cmpapi('getTCData', 2, function (tcData) {
       if (tcData.cmpStatus === 'loaded') {
         var consent = tcData.vendor.consents[CMP_VENDOR_ID];
         if (consent === true) {

--- a/examples/consent-with-agtt-banner.html
+++ b/examples/consent-with-agtt-banner.html
@@ -11,10 +11,10 @@
     //<![CDATA[
     var isShowingBanner = false;
 
-    // when banner is closed, __tcfapi is used to save the user's consent decision
+    // when banner is closed, __cmpapi is used to save the user's consent decision
     function bannerClosedCallback(consentDecision) {
       if (consentDecision === true || consentDecision === false) {
-        window.__tcfapi('setConsent', 2, function (consent) {
+        window.__cmpapi('setConsent', 2, function (consent) {
           if (consent === true) {
             console.log('Consent accepted');
           }
@@ -58,7 +58,7 @@
 
     // we load consent data on page load and show the banner if no consent decision is saved yet
     var CMP_VENDOR_ID = 4040;
-    window.__tcfapi('getTCData', 2, function (tcData) {
+    window.__cmpapi('getTCData', 2, function (tcData) {
       if (tcData.cmpStatus === 'loaded') {
         var consent = tcData.vendor.consents[CMP_VENDOR_ID];
         if (consent === undefined) {

--- a/examples/consent-with-tracking-and-agtt-banner.html
+++ b/examples/consent-with-tracking-and-agtt-banner.html
@@ -12,10 +12,10 @@
     //<![CDATA[
     var isShowingBanner = false;
 
-    // when banner is closed, __tcfapi is used to save the user's consent decision
+    // when banner is closed, __cmpapi is used to save the user's consent decision
     function bannerClosedCallback(consentDecision) {
       if (consentDecision === true || consentDecision === false) {
-        window.__tcfapi('setConsent', 2, function (consent) {
+        window.__cmpapi('setConsent', 2, function (consent) {
           if (consent === true) {
             console.log('Consent accepted');
           }
@@ -59,7 +59,7 @@
 
     // we load consent data on page load and show the banner if no consent decision is saved yet
     var CMP_VENDOR_ID = 4040;
-    window.__tcfapi('getTCData', 2, function (tcData) {
+    window.__cmpapi('getTCData', 2, function (tcData) {
       if (tcData.cmpStatus === 'loaded') {
         var consent = tcData.vendor.consents[CMP_VENDOR_ID];
         if (consent === undefined) {

--- a/index.ejs
+++ b/index.ejs
@@ -13,7 +13,7 @@
 
     function bannerClosedCallback(consentDecision) {
       if (consentDecision === true || consentDecision === false) {
-        window.__tcfapi('setConsent', 2, function (consent) {
+        window.__cmpapi('setConsent', 2, function (consent) {
           if (consent === true) {
             console.log('Consent accepted');
           }
@@ -56,7 +56,7 @@
     window.addEventListener('keydown', keyHandler);
 
     var CMP_VENDOR_ID = 4040;
-    window.__tcfapi('getTCData', 2, function (tcData) {
+    window.__cmpapi('getTCData', 2, function (tcData) {
       if (tcData.cmpStatus === 'loaded') {
         var consent = tcData.vendor.consents[CMP_VENDOR_ID];
         if (consent === undefined) {
@@ -71,7 +71,7 @@
       }
     });
 
-    window.__tcfapi('onLogEvent', 2, function ({ event, success, parameters, ts }) {
+    window.__cmpapi('onLogEvent', 2, function ({ event, success, parameters, ts }) {
       console.warn("logEvent", event, success, parameters, ts);
     });
     //]]>

--- a/spec/api.spec.js
+++ b/spec/api.spec.js
@@ -17,7 +17,7 @@ describe("API is called right after loading", () => {
   beforeAll(async () => {
     await page.goto(`${pageHelper.HTTP_PROTOCOL}://${pageHelper.HTTP_HOST}/health`);
     await pageHelper.initLoader(page);
-    apiResponse = await page.evaluate(`(new Promise((resolve)=>{window.__tcfapi('getTCData', 1, resolve)}))`);
+    apiResponse = await page.evaluate(`(new Promise((resolve)=>{window.__cmpapi('getTCData', 1, resolve)}))`);
   });
 
   test("Callback is eventually called", () => {

--- a/spec/backward-compatibility-tcfapi.spec.js
+++ b/spec/backward-compatibility-tcfapi.spec.js
@@ -1,0 +1,42 @@
+const { describe, beforeAll, afterAll, test, expect } = require("@jest/globals");
+const pageHelper = require("./helper/page");
+let page;
+
+beforeAll(async () => {
+  page = await pageHelper.get();
+}, 20000);
+
+afterAll(async () => {
+  await page.browser().close();
+}, 20000);
+
+describe("Backward compatibility", () => {
+  beforeAll(async () => {
+    await page.goto(`${pageHelper.HTTP_PROTOCOL}://${pageHelper.HTTP_HOST}/health`);
+    await pageHelper.initLoader(page);
+  });
+
+  test("Ping API call returns basic configuration", async () => {
+    const result = page.evaluate(`(new Promise((resolve)=>{window.__tcfapi('ping', 1, resolve)}))`);
+
+    return expect(result).resolves.toEqual({
+      apiVersion: "2.0",
+      cmpId: 4040,
+      cmpLoaded: true,
+      cmpStatus: "loaded",
+      cmpVersion: 1,
+      displayStatus: "hidden",
+      gdprApplies: true,
+      gvlVersion: 1,
+      tcfPolicyVersion: 2,
+    });
+  });
+
+  test("Storage status is disabled", async () => {
+    const apiResponse = await page.evaluate(`(new Promise((resolve)=>{window.__tcfapi('getTCData', 1, resolve)}))`);
+
+    expect(apiResponse.cmpStatus).toBe("disabled");
+    expect(apiResponse.vendor["consents"]).toBeDefined();
+    expect(apiResponse.vendor["consents"]["4040"]).toBeUndefined();
+  });
+});

--- a/spec/banner-no-iframe.spec.js
+++ b/spec/banner-no-iframe.spec.js
@@ -31,7 +31,7 @@ describe("Consent Management with banner", () => {
       await page.evaluate(function () {
         window.__cbapi("showBanner", 2, function (consentDecision) {
           if (typeof consentDecision === "boolean") {
-            window.__tcfapi("setConsent", 2, undefined, consentDecision);
+            window.__cmpapi("setConsent", 2, undefined, consentDecision);
           }
         });
       });
@@ -75,7 +75,7 @@ describe("Consent Management with banner", () => {
           await page.evaluate(function () {
             window.__cbapi("showBanner", 2, function (consentDecision) {
               if (typeof consentDecision === "boolean") {
-                window.__tcfapi("setConsent", 2, undefined, consentDecision);
+                window.__cmpapi("setConsent", 2, undefined, consentDecision);
               }
             });
           });

--- a/spec/banner.spec.js
+++ b/spec/banner.spec.js
@@ -30,7 +30,7 @@ describe("Consent Management with banner", () => {
       await page.evaluate(function () {
         window.__cbapi("showBanner", 2, function (consentDecision) {
           if (typeof consentDecision === "boolean") {
-            window.__tcfapi("setConsent", 2, undefined, consentDecision);
+            window.__cmpapi("setConsent", 2, undefined, consentDecision);
           }
         });
       });
@@ -74,7 +74,7 @@ describe("Consent Management with banner", () => {
           await page.evaluate(function () {
             window.__cbapi("showBanner", 2, function (consentDecision) {
               if (typeof consentDecision === "boolean") {
-                window.__tcfapi("setConsent", 2, undefined, consentDecision);
+                window.__cmpapi("setConsent", 2, undefined, consentDecision);
               }
             });
           });

--- a/spec/channel.spec.js
+++ b/spec/channel.spec.js
@@ -11,12 +11,12 @@ afterAll(async () => {
 }, 20000);
 
 describe("Consent Management with ServusTv channelId", () => {
-  let iframeResponse, tcfapiResponse;
+  let iframeResponse, cmpapiResponse;
 
   beforeAll(async () => {
     await page.goto(`${pageHelper.HTTP_PROTOCOL}://${pageHelper.HTTP_HOST}/health`);
     iframeResponse = page.waitForResponse((response) => response.url().includes("iframe.html"));
-    tcfapiResponse = page.waitForResponse((response) => response.url().includes("tcfapi"));
+    cmpapiResponse = page.waitForResponse((response) => response.url().includes("cmpapi"));
     await pageHelper.initLoader(page, 0);
   });
 
@@ -24,14 +24,14 @@ describe("Consent Management with ServusTv channelId", () => {
     expect((await iframeResponse).url()).toContain("channelId=0");
   });
 
-  test("Passing through channelId for tcfapi request", async () => {
-    expect((await tcfapiResponse).url()).toContain("channelId=0");
+  test("Passing through channelId for cmpapi request", async () => {
+    expect((await cmpapiResponse).url()).toContain("channelId=0");
   });
 
   describe("When consent is set", () => {
     let setConsentResponse = beforeAll(async () => {
       setConsentResponse = page.waitForResponse((response) => response.url().includes("set-consent"));
-      await page.evaluate(`(new Promise((resolve)=>{window.__tcfapi('setConsent', 2, resolve, true);}))`);
+      await page.evaluate(`(new Promise((resolve)=>{window.__cmpapi('setConsent', 2, resolve, true);}))`);
     });
 
     test("Passing through channelId for setConsent request", async () => {

--- a/spec/consent-flow.spec.js
+++ b/spec/consent-flow.spec.js
@@ -23,7 +23,7 @@ describe("Consent Management with technical cookie", () => {
     });
 
     test("Storage status is enabled and consent is false", async () => {
-      const apiResponse = await page.evaluate(`(new Promise((resolve)=>{window.__tcfapi('getTCData', 2, resolve)}))`);
+      const apiResponse = await page.evaluate(`(new Promise((resolve)=>{window.__cmpapi('getTCData', 2, resolve)}))`);
 
       expect(apiResponse.cmpStatus).toBe("loaded");
       expect(apiResponse.vendor["consents"]).toBeDefined();
@@ -32,12 +32,12 @@ describe("Consent Management with technical cookie", () => {
 
     describe("When consent is given", () => {
       beforeAll(async () => {
-        await page.evaluate(`(new Promise((resolve)=>{window.__tcfapi('setConsent', 1, resolve, true);}))`);
+        await page.evaluate(`(new Promise((resolve)=>{window.__cmpapi('setConsent', 1, resolve, true);}))`);
         await pageHelper.initLoader(page);
       });
 
       test("Storage status is enabled and consent is true", async () => {
-        const apiResponse = await page.evaluate(`(new Promise((resolve)=>{window.__tcfapi('getTCData', 2, resolve)}))`);
+        const apiResponse = await page.evaluate(`(new Promise((resolve)=>{window.__cmpapi('getTCData', 2, resolve)}))`);
 
         console.log(JSON.stringify(apiResponse));
         expect(apiResponse.cmpStatus).toBe("loaded");

--- a/spec/core.spec.js
+++ b/spec/core.spec.js
@@ -17,7 +17,7 @@ describe("Consent Management is loaded", () => {
   });
 
   test("Ping API call returns basic configuration", async () => {
-    const result = page.evaluate(`(new Promise((resolve)=>{window.__tcfapi('ping', 1, resolve)}))`);
+    const result = page.evaluate(`(new Promise((resolve)=>{window.__cmpapi('ping', 1, resolve)}))`);
 
     return expect(result).resolves.toEqual({
       apiVersion: "2.0",
@@ -33,7 +33,7 @@ describe("Consent Management is loaded", () => {
   });
 
   test("Storage status is disabled", async () => {
-    const apiResponse = await page.evaluate(`(new Promise((resolve)=>{window.__tcfapi('getTCData', 1, resolve)}))`);
+    const apiResponse = await page.evaluate(`(new Promise((resolve)=>{window.__cmpapi('getTCData', 1, resolve)}))`);
 
     expect(apiResponse.cmpStatus).toBe("disabled");
     expect(apiResponse.vendor["consents"]).toBeDefined();

--- a/spec/debug-api.spec.js
+++ b/spec/debug-api.spec.js
@@ -23,7 +23,7 @@ describe("Debug API", () => {
       await page.evaluate(() => {
         return new Promise((resolve) => {
           window.callbackQueue = [];
-          window.__tcfapi("onLogEvent", 2, function (params) {
+          window.__cmpapi("onLogEvent", 2, function (params) {
             window.callbackQueue.push(params);
           });
           resolve();
@@ -36,7 +36,7 @@ describe("Debug API", () => {
       beforeAll(async () => {
         await page.evaluate(() => {
           return new Promise((resolve) => {
-            window.__tcfapi("getTCData", 2, resolve);
+            window.__cmpapi("getTCData", 2, resolve);
           });
         });
         await wait(100);
@@ -75,7 +75,7 @@ describe("Debug API", () => {
           consentCookieLoaded = page.waitForResponse((response) => response.url().includes("set-consent"));
           await page.evaluate(() => {
             return new Promise((resolve) => {
-              window.__tcfapi("setConsent", 2, resolve, false);
+              window.__cmpapi("setConsent", 2, resolve, false);
             });
           });
           await consentCookieLoaded;

--- a/spec/helper/page.js
+++ b/spec/helper/page.js
@@ -15,7 +15,7 @@ async function get() {
 }
 
 async function initLoader(page, channelId = undefined, withBanner = false) {
-  const isLoaded = page.waitForResponse((response) => response.url().includes("tcfapi"));
+  const isLoaded = page.waitForResponse((response) => response.url().includes("cmpapi"));
   await page.setContent(
     `<script type='text/javascript' src="${HTTP_PROTOCOL}://${HTTP_HOST}/${API_VERSION}/cmp.js${
       channelId !== undefined ? "?channelId=" + channelId : ""

--- a/spec/noconsent-flow.spec.js
+++ b/spec/noconsent-flow.spec.js
@@ -23,7 +23,7 @@ describe("Consent Management with technical cookie", () => {
     });
 
     test("Storage status is enabled and consent is false", async () => {
-      const apiResponse = await page.evaluate(`(new Promise((resolve)=>{window.__tcfapi('getTCData', 2, resolve)}))`);
+      const apiResponse = await page.evaluate(`(new Promise((resolve)=>{window.__cmpapi('getTCData', 2, resolve)}))`);
 
       expect(apiResponse.cmpStatus).toBe("loaded");
       expect(apiResponse.vendor["consents"]).toBeDefined();
@@ -32,12 +32,12 @@ describe("Consent Management with technical cookie", () => {
 
     describe("When consent is declined", () => {
       beforeAll(async () => {
-        await page.evaluate(`(new Promise((resolve)=>{window.__tcfapi('setConsent', 1, resolve, false);}))`);
+        await page.evaluate(`(new Promise((resolve)=>{window.__cmpapi('setConsent', 1, resolve, false);}))`);
         await pageHelper.initLoader(page);
       });
 
       test("Storage status is enabled and consent is false", async () => {
-        const apiResponse = await page.evaluate(`(new Promise((resolve)=>{window.__tcfapi('getTCData', 2, resolve)}))`);
+        const apiResponse = await page.evaluate(`(new Promise((resolve)=>{window.__cmpapi('getTCData', 2, resolve)}))`);
 
         console.log(JSON.stringify(apiResponse));
         expect(apiResponse.cmpStatus).toBe("loaded");

--- a/spec/presto-useragent.spec.js
+++ b/spec/presto-useragent.spec.js
@@ -18,19 +18,19 @@ describe("Consent Management with Presto user agent", () => {
   });
 
   describe("Is loaded", () => {
-    let tcfapiJsLoaded;
+    let cmpapiJsLoaded;
 
     beforeAll(async () => {
-      tcfapiJsLoaded = page.waitForResponse((response) => response.url().includes("tcfapi.js"));
+      cmpapiJsLoaded = page.waitForResponse((response) => response.url().includes("cmpapi.js"));
       await pageHelper.initLoader(page);
     });
 
     test("Loads 3rd party version of API", async () => {
-      expect(await tcfapiJsLoaded).toBeDefined();
+      expect(await cmpapiJsLoaded).toBeDefined();
     });
 
     test("Storage status is enabled and consent is false", async () => {
-      const apiResponse = await page.evaluate(`(new Promise((resolve)=>{window.__tcfapi('getTCData', 2, resolve)}))`);
+      const apiResponse = await page.evaluate(`(new Promise((resolve)=>{window.__cmpapi('getTCData', 2, resolve)}))`);
 
       expect(apiResponse.cmpStatus).toBe("loaded");
       expect(apiResponse.vendor["consents"]).toBeDefined();

--- a/spec/sample-rate.spec.ts
+++ b/spec/sample-rate.spec.ts
@@ -34,7 +34,7 @@ describe("Consent Management API configured with 0% sample rate", () => {
     let response: Response;
 
     beforeAll(async () => {
-      response = await request(app).get("/v2/tcfapi.js");
+      response = await request(app).get("/v2/cmpapi.js");
     });
 
     test("cmpStatus is disabled", () => {
@@ -53,7 +53,7 @@ describe("Consent Management API configured with 0% sample rate", () => {
     let response: Response;
 
     beforeAll(async () => {
-      response = await request(app).get("/v2/tcfapi.js?consent=true");
+      response = await request(app).get("/v2/cmpapi.js?consent=true");
     });
 
     test("cmpStatus is loaded", () => {
@@ -70,7 +70,7 @@ describe("Consent Management API configured with 0% sample rate", () => {
     let response: Response;
 
     beforeAll(async () => {
-      response = await request(app).get("/v2/tcfapi.js?consent=false");
+      response = await request(app).get("/v2/cmpapi.js?consent=false");
     });
 
     test("cmpStatus is loaded", () => {
@@ -87,7 +87,7 @@ describe("Consent Management API configured with 0% sample rate", () => {
     let response: Response;
 
     beforeAll(async () => {
-      response = await request(app).get("/v2/tcfapi.js?consent=undefined");
+      response = await request(app).get("/v2/cmpapi.js?consent=undefined");
     });
 
     test("cmpStatus is disabled", () => {
@@ -106,7 +106,7 @@ describe("Consent Management API configured with 0% sample rate", () => {
     let response: Response;
 
     beforeAll(async () => {
-      response = await request(app).get(`/v2/tcfapi.js?xt=${Date.now() - 100}`);
+      response = await request(app).get(`/v2/cmpapi.js?xt=${Date.now() - 100}`);
     });
 
     test("cmpStatus is disabled", () => {
@@ -125,7 +125,7 @@ describe("Consent Management API configured with 0% sample rate", () => {
     let response: Response;
 
     beforeAll(async () => {
-      response = await request(app).get(`/v2/tcfapi.js?xt=${Date.now() - 1000000}`);
+      response = await request(app).get(`/v2/cmpapi.js?xt=${Date.now() - 1000000}`);
     });
 
     test("cmpStatus is disabled due to sample rate", () => {

--- a/src/controller/cmpapi.ts
+++ b/src/controller/cmpapi.ts
@@ -4,13 +4,13 @@ import { logger } from "../util/logger";
 
 import { getTemplateValues } from "./util/getTemplateValues";
 
-export const tcfapiController = async (req: Request, res: Response) => {
+export const cmpapiController = async (req: Request, res: Response) => {
   res.setHeader("Content-Type", "application/javascript");
   res.setHeader("Cache-Control", "no-store");
 
   try {
     const values = getTemplateValues(req);
-    res.render("tcfapi.js", values);
+    res.render("cmpapi.js", values);
   } catch (e) {
     logger.error(e);
     res.status(500).send(e);

--- a/src/controller/cmpapiIframe.ts
+++ b/src/controller/cmpapiIframe.ts
@@ -4,17 +4,17 @@ import path from "path";
 
 import { getTemplateValues } from "./util/getTemplateValues";
 
-export const tcfapiInnerController = async (req: Request, res: Response) => {
+export const cmpapiIframeController = async (req: Request, res: Response) => {
   res.setHeader("Content-Type", "application/javascript");
   res.setHeader("Cache-Control", "no-store");
 
   try {
     const values = getTemplateValues(req, "iframe");
 
-    const tcfapiJs = await renderFile(path.join(__dirname, "../templates/tcfapi.js"), values);
+    const cmpapiJs = await renderFile(path.join(__dirname, "../templates/cmpapi.js"), values);
     const iframeMsgJs = await renderFile(path.join(__dirname, "../templates/iframe-msg.js"));
 
-    res.send(`${tcfapiJs}${iframeMsgJs}`);
+    res.send(`${cmpapiJs}${iframeMsgJs}`);
   } catch (e) {
     res.status(500).send(e);
   }

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -1,8 +1,8 @@
 export { bannerController } from "./banner";
 export { cmpWithTrackingController } from "./cmpWithTracking";
 export { cmpController } from "./cmp";
-export { tcfapiController } from "./tcfapi";
-export { tcfapiInnerController } from "./tcfapiInner";
+export { cmpapiController } from "./cmpapi";
+export { cmpapiIframeController } from "./cmpapiIframe";
 export { iframeController } from "./iframe";
 export { setConsentController } from "./setConsent";
 export { removeConsentController } from "./removeConsent";

--- a/src/router.ts
+++ b/src/router.ts
@@ -9,8 +9,8 @@ import {
   iframeController,
   removeConsentController,
   setConsentController,
-  tcfapiController,
-  tcfapiInnerController,
+  cmpapiController,
+  cmpapiIframeController,
 } from "./controller";
 
 import { loggerMiddleware, techCookieMiddleware, channelMiddleware } from "./middleware";
@@ -29,7 +29,7 @@ router.get("/cmp-with-tracking.js", cmpWithTrackingController);
 router.get("/iframe.html", iframeController);
 router.get("/remove-consent", removeConsentController);
 router.get("/set-consent", setConsentController);
-router.get("/tcfapi.js", tcfapiController);
-router.get("/tcfapi-inner.js", tcfapiInnerController);
+router.get("/cmpapi.js", cmpapiController);
+router.get("/cmpapi-iframe.js", cmpapiIframeController);
 
 export default router;

--- a/src/templates/cmp.js
+++ b/src/templates/cmp.js
@@ -2,11 +2,11 @@
   var queue = [];
   var logEntries = [];
 
-  window.__tcfapi = function (command, version, callback, parameter) {
+  window.__cmpapi = function (command, version, callback, parameter) {
     queue[queue.length] = Array.prototype.slice.call(arguments, 0);
   };
 
-  window.__tcfapi('onLogEvent', 2, function () {
+  window.__cmpapi('onLogEvent', 2, function () {
     logEntries[logEntries.length] = Array.prototype.slice.call(arguments, 0);
   });
 
@@ -39,7 +39,7 @@
 
     for (var i = 0; i < queue.length; i++) {
       var f = queue[i];
-      window.__tcfapi.apply(null, f.slice(0));
+      window.__cmpapi.apply(null, f.slice(0));
     }
 
     queue = [];
@@ -65,7 +65,7 @@
   }
 
   function log(event, success, parameters) {
-    window.__tcfapi('log', 2, function () {}, JSON.stringify({ event: event, parameters: parameters }));
+    window.__cmpapi('log', 2, function () {}, JSON.stringify({ event: event, parameters: parameters }));
   }
 
   function isIframeCapable() {
@@ -102,7 +102,7 @@
         return;
       }
 
-      window.__tcfapi = function (command, version, callback, parameter) {
+      window.__cmpapi = function (command, version, callback, parameter) {
         message('cmd', command, version, callback, parameter);
       };
 
@@ -156,7 +156,7 @@
     body.appendChild(iframe);
   }
 
-  function createTcfapiScriptTag() {
+  function createCmpApiScriptTag() {
     var techCookieTimestamp = '<%-TECH_COOKIE_TIMESTAMP%>';
     var hasConsent = null;
 
@@ -170,25 +170,25 @@
       }
     }
 
-    var tcfapiScriptTag = document.createElement('script');
-    tcfapiScriptTag.setAttribute('type', 'text/javascript');
-    tcfapiScriptTag.setAttribute(
+    var cmpapiScriptTag = document.createElement('script');
+    cmpapiScriptTag.setAttribute('type', 'text/javascript');
+    cmpapiScriptTag.setAttribute(
       'src',
-      '<%-CONSENT_SERVER_PROTOCOL%>://<%-CONSENT_SERVER_HOST%>/<%-API_VERSION%>/tcfapi.js?<%-TECH_COOKIE_NAME%>=' +
+      '<%-CONSENT_SERVER_PROTOCOL%>://<%-CONSENT_SERVER_HOST%>/<%-API_VERSION%>/cmpapi.js?<%-TECH_COOKIE_NAME%>=' +
         techCookieTimestamp +
         (hasConsent !== null ? '&consent=' + hasConsent : '') +
         (channelId !== '' ? '&channelId=' + channelId : ''),
     );
 
-    tcfapiScriptTag.onload = function () {
+    cmpapiScriptTag.onload = function () {
       onAPILoaded('3rdparty');
     };
 
-    tcfapiScriptTag.onerror = function () {
+    cmpapiScriptTag.onerror = function () {
       log('loaded', false, { type: '3rdparty' });
     };
 
-    return tcfapiScriptTag;
+    return cmpapiScriptTag;
   }
 
   function loadTcfapi(retriesLeft) {
@@ -204,8 +204,8 @@
       return;
     }
 
-    var tcfapiScriptTag = createTcfapiScriptTag();
-    head.appendChild(tcfapiScriptTag);
+    var cmpapiScriptTag = createCmpApiScriptTag();
+    head.appendChild(cmpapiScriptTag);
   }
 
   if (isIframeCapable()) {

--- a/src/templates/cmp.js
+++ b/src/templates/cmp.js
@@ -6,6 +6,9 @@
     queue[queue.length] = Array.prototype.slice.call(arguments, 0);
   };
 
+  // fallback for old __tcfapi implementation
+  window.__tcfapi = window.__cmpapi;
+
   window.__cmpapi('onLogEvent', 2, function () {
     logEntries[logEntries.length] = Array.prototype.slice.call(arguments, 0);
   });
@@ -98,13 +101,16 @@
     iframe.onload = function () {
       if (!iframe.contentWindow || !iframe.contentWindow.postMessage) {
         iframe.parentElement.removeChild(iframe);
-        loadTcfapi(3);
+        loadCmpApi(3);
         return;
       }
 
       window.__cmpapi = function (command, version, callback, parameter) {
         message('cmd', command, version, callback, parameter);
       };
+
+      // fallback for old __tcfapi implementation
+      window.__tcfapi = window.__cmpapi;
 
       window.addEventListener(
         'message',
@@ -191,7 +197,7 @@
     return cmpapiScriptTag;
   }
 
-  function loadTcfapi(retriesLeft) {
+  function loadCmpApi(retriesLeft) {
     if (retriesLeft < 0) {
       return;
     }
@@ -199,7 +205,7 @@
     var head = document.getElementsByTagName('head')[0];
     if (!head) {
       setTimeout(function () {
-        loadTcfapi(retriesLeft - 1);
+        loadCmpApi(retriesLeft - 1);
       }, 100);
       return;
     }
@@ -211,6 +217,6 @@
   if (isIframeCapable()) {
     loadIframe(3);
   } else {
-    loadTcfapi(3);
+    loadCmpApi(3);
   }
 })();

--- a/src/templates/cmpWithTracking.js
+++ b/src/templates/cmpWithTracking.js
@@ -31,7 +31,7 @@
     document.getElementsByTagName('head')[0].appendChild(trackingScriptTag);
   };
 
-  window.__tcfapi('getTCData', 2, function (tcData) {
+  window.__cmpapi('getTCData', 2, function (tcData) {
     initTracking(tcData.vendor.consents['<%-CMP_ID%>']);
   });
 })();

--- a/src/templates/cmpapi.js
+++ b/src/templates/cmpapi.js
@@ -131,3 +131,6 @@ window.__cmpapi = function (command, version, callback, parameter) {
       break;
   }
 };
+
+// fallback for old __tcfapi implementation
+window.__tcfapi = window.__cmpapi;

--- a/src/templates/cmpapi.js
+++ b/src/templates/cmpapi.js
@@ -1,6 +1,6 @@
 var logCallback;
 
-window.__tcfapi = function (command, version, callback, parameter) {
+window.__cmpapi = function (command, version, callback, parameter) {
   var channelId = '<%-CHANNEL_ID%>';
 
   var hasConsent = '<%-TC_CONSENT%>' === 'undefined' ? undefined : '<%-TC_CONSENT%>' === 'true';

--- a/src/templates/iframe-msg.js
+++ b/src/templates/iframe-msg.js
@@ -15,7 +15,7 @@
           var cmd = message[2];
           var version = message[3];
           var param = JSON.parse(message[4]);
-          __tcfapi(
+          __cmpapi(
             cmd,
             version,
             function (cbParam) {

--- a/src/templates/iframe.html
+++ b/src/templates/iframe.html
@@ -23,10 +23,10 @@
         }
       }
 
-      var tcfapiScriptTag = document.createElement('script');
-      tcfapiScriptTag.setAttribute('src', '<%-CONSENT_SERVER_PROTOCOL%>://<%-CONSENT_SERVER_HOST%>/<%-API_VERSION%>/tcfapi-inner.js?<%-TECH_COOKIE_NAME%>=' + techCookieTimestamp + (hasConsent !== null ? '&consent=' + hasConsent : '') + (channelId !== '' ? '&channelId=' + channelId : ''));
-      tcfapiScriptTag.setAttribute('type', 'text/javascript');
-      document.getElementsByTagName('head')[0].appendChild(tcfapiScriptTag);
+      var cmpApiScriptTag = document.createElement('script');
+      cmpApiScriptTag.setAttribute('src', '<%-CONSENT_SERVER_PROTOCOL%>://<%-CONSENT_SERVER_HOST%>/<%-API_VERSION%>/cmpapi-iframe.js?<%-TECH_COOKIE_NAME%>=' + techCookieTimestamp + (hasConsent !== null ? '&consent=' + hasConsent : '') + (channelId !== '' ? '&channelId=' + channelId : ''));
+      cmpApiScriptTag.setAttribute('type', 'text/javascript');
+      document.getElementsByTagName('head')[0].appendChild(cmpApiScriptTag);
     } catch (e) { }
     //]]>
   </script>


### PR DESCRIPTION
In order to avoid possible collisions with existing/implemented consent solutions based on [TCFv2](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md) we want to change the API namespace.