### PR TITLE
Fix for visible iframe borders on some Samsung devices

### DIFF
--- a/src/templates/cmp.js
+++ b/src/templates/cmp.js
@@ -92,7 +92,7 @@
       '<%-CONSENT_SERVER_PROTOCOL%>://<%-CONSENT_SERVER_HOST%>/<%-API_VERSION%>/iframe.html' +
         (channelId !== '' ? '?channelId=' + channelId : ''),
     );
-    iframe.setAttribute('style', 'border:0;outline:0;width:0;height:0;');
+    iframe.setAttribute('style', 'position:fixed;border:0;outline:0;top:-999px;left:-999px;width:0;height:0;');
     iframe.setAttribute('frameborder', '0');
 
     iframe.onload = function () {


### PR DESCRIPTION
Because some Samsung have a bug where invisible iframe borders are sometimes visible, this change moves iframe position from top left position outside of viewport.