### PR TITLE
remove Device ID collection

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -26,6 +26,3 @@ export const TRACKING_HOST_NO_CONSENT = new EnvVar("TRACKING_HOST_NO_CONSENT").g
   "session-cl.tvping.com",
 );
 export const TRACKING_VERSION = new EnvVar("TRACKING_VERSION").getStringOrDefault("v2");
-export const SUBMIT_CONSENT_FOR_TRACKING_DEVICE_ID_URL = new EnvVar(
-  "SUBMIT_CONSENT_FOR_TRACKING_DEVICE_ID_URL",
-).getStringOrDefault("http://session.tvping.com/v2/consent-status");

--- a/src/controller/cmp.ts
+++ b/src/controller/cmp.ts
@@ -1,12 +1,6 @@
 import { Request, Response } from "express";
 
-import {
-  API_VERSION,
-  HTTP_HOST,
-  TECH_COOKIE_NAME,
-  COOKIE_NAME,
-  SUBMIT_CONSENT_FOR_TRACKING_DEVICE_ID_URL,
-} from "../config";
+import { API_VERSION, HTTP_HOST, TECH_COOKIE_NAME, COOKIE_NAME } from "../config";
 import { loadedCounterMetric } from "../util/metrics";
 
 export const cmpController = async (req: Request, res: Response) => {
@@ -24,7 +18,6 @@ export const cmpController = async (req: Request, res: Response) => {
       CONSENT_SERVER_HOST: HTTP_HOST,
       CONSENT_SERVER_PROTOCOL: req.protocol,
       CHANNEL_ID: req.channelId,
-      SUBMIT_CONSENT_FOR_TRACKING_DEVICE_ID_URL,
     });
   } catch (e) {
     res.status(500).send(e);

--- a/src/controller/cmpWithTracking.ts
+++ b/src/controller/cmpWithTracking.ts
@@ -10,7 +10,6 @@ import {
   TRACKING_HOST_CONSENT,
   TRACKING_HOST_NO_CONSENT,
   TRACKING_PROTOCOL,
-  SUBMIT_CONSENT_FOR_TRACKING_DEVICE_ID_URL,
 } from "../config";
 
 export const cmpWithTrackingController = async (req: Request, res: Response) => {
@@ -36,7 +35,6 @@ export const cmpWithTrackingController = async (req: Request, res: Response) => 
       CONSENT_SERVER_HOST: HTTP_HOST,
       CONSENT_SERVER_PROTOCOL: req.protocol,
       CHANNEL_ID: req.channelId,
-      SUBMIT_CONSENT_FOR_TRACKING_DEVICE_ID_URL,
     });
     const trackingJs = await renderFile(path.join(__dirname, "../templates/cmpWithTracking.js"), {
       CHANNEL_ID: req.channelId,

--- a/src/templates/cmp.js
+++ b/src/templates/cmp.js
@@ -189,46 +189,4 @@
   } else {
     loadCmpApi(3);
   }
-
-  // send device ids
-  function sendDeviceId(consent, retriesLeft) {
-    if (retriesLeft < 0) {
-      return;
-    }
-
-    if (!__hbb_tracking_tgt || !__hbb_tracking_tgt.getDID) {
-      setTimeout(function () {
-        sendDeviceId(consent, retriesLeft - 1);
-      }, 100);
-      return;
-    }
-
-    __hbb_tracking_tgt.getDID(function (deviceId) {
-      var image = document.createElement('img');
-      image.src =
-        '<%-SUBMIT_CONSENT_FOR_TRACKING_DEVICE_ID_URL%>/' +
-        deviceId +
-        '/' +
-        Date.now() +
-        '/consent.gif?consent=' +
-        consent;
-    });
-  }
-
-  function waitForTrackingScriptAndSendDeviceId(consent) {
-    sendDeviceId(consent, 3);
-  }
-
-  window.__tcfapi('onLogEvent', 2, function (log) {
-    var consent = undefined;
-    if (log.success === true && (log.event === 'getTCData' || log.event === 'setConsent')) {
-      consent = log.parameters.consent;
-    }
-
-    if (consent !== undefined) {
-      try {
-        waitForTrackingScriptAndSendDeviceId(consent);
-      } catch (e) {}
-    }
-  });
 })();


### PR DESCRIPTION
The collection of Device IDs is no longer necessary as Device IDs for future model training can be determined by the usage of the cookiefull tracking endpoint (the decision cookiefull vs cookieless tracking endpoint is bound to the consent decision)