### PR TITLE
Fallback for when body takes too long to load

### DIFF
--- a/src/templates/cmp.js
+++ b/src/templates/cmp.js
@@ -109,8 +109,19 @@
     return iframe;
   }
 
+  function loadOnDomContentLoad() {
+    window.addEventListener('DOMContentLoaded', function () {
+      if (isIframeCapable()) {
+        loadIframe(3);
+      } else {
+        loadCmpApi(3);
+      }
+    });
+  }
+
   function loadIframe(retriesLeft) {
     if (retriesLeft < 0) {
+      loadOnDomContentLoad();
       return;
     }
 
@@ -163,6 +174,7 @@
 
   function loadCmpApi(retriesLeft) {
     if (retriesLeft < 0) {
+      loadOnDomContentLoad();
       return;
     }
 


### PR DESCRIPTION
In case of e.g. a slow internet connection, it can happen that the body cannot be found within the 400ms the `cmp.js` scripts try to inject the necessary code to run the CMP.

This PR introduces an additional method, that in case the existing retry logic fails, the `cmp.js` loader script waits for the `DOMContentLoaded` event, and only then initialises the CMP.