### PR TITLE
Fallback for when body takes too long to load

### DIFF
--- a/index.ejs
+++ b/index.ejs
@@ -11,7 +11,7 @@
     window.setTimeout(function () {
       window.__hbb_tracking_tgt = {
         getDID: function (callback) {
-          if (typeof callback === 'function') {
+          if (callback && typeof callback === 'function') {
             callback('TEST_DID');
           }
         }
@@ -19,8 +19,8 @@
     }, 200);
     //]]>
   </script>
-  <script type='text/javascript' src='http://localhost:4000/v2/cmp.js?channelId=0'></script>
-  <script type='text/javascript' src='http://localhost:4000/v2/banner.js?channelId=0'></script>
+  <script type='text/javascript' src='http://localhost:3000/v2/cmp.js?channelId=0'></script>
+  <script type='text/javascript' src='http://localhost:3000/v2/banner.js?channelId=0'></script>
   <script>
     //<![CDATA[
     var isShowingBanner = false;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint --ext .ts,.js src",
     "lint:apply": "eslint --ext .ts,.js src --fix"
   },
-  "author": "Alexander Futász <alexander.futasz@fokus.fraunhofer.de>",
+  "author": "Andreas Jantschnig <andreas.jantschnig@tv-insight>",
   "license": "UNLICENSED",
   "dependencies": {
     "cookie-parser": "^1.4.6",

--- a/src/templates/banner.js
+++ b/src/templates/banner.js
@@ -123,7 +123,7 @@ function loadOnDOMContentLoaded(callback) {
   });
 }
 
-function waitForDomElement(elementId, success, fail, retriesLeft) {
+function waitForDOMElement(elementId, success, fail, retriesLeft) {
   if (retriesLeft < 0) {
     if (fail && typeof fail === 'function') {
       fail();
@@ -138,7 +138,7 @@ function waitForDomElement(elementId, success, fail, retriesLeft) {
 
   if (!element) {
     setTimeout(function () {
-      waitForDomElement(elementId, success, fail, retriesLeft - 1);
+      waitForDOMElement(elementId, success, fail, retriesLeft - 1);
     }, 200);
     return;
   }
@@ -277,7 +277,7 @@ window.__cbapi = function (command, version, callback, parameter) {
 
   switch (command) {
     case 'showBanner':
-      waitForDomElement(
+      waitForDOMElement(
         parameter,
         function () {
           showConsentBanner(parameter, callback);

--- a/src/templates/banner.js
+++ b/src/templates/banner.js
@@ -115,19 +115,17 @@ function buildBannerElement() {
   return bannerOuter;
 }
 
-function loadOnDOMContentLoaded(callback) {
+function loadOnDOMContentLoaded(domContentLoadedCB) {
   document.addEventListener('DOMContentLoaded', function () {
-    if (callback && typeof callback === 'function') {
-      callback();
+    if (domContentLoadedCB && typeof domContentLoadedCB === 'function') {
+      domContentLoadedCB();
     }
   });
 }
 
-function waitForDOMElement(elementId, success, fail, retriesLeft) {
+function waitForDOMElement(elementId, onDomElementFoundCB, retriesLeft) {
   if (retriesLeft < 0) {
-    if (fail && typeof fail === 'function') {
-      fail();
-    }
+    loadOnDOMContentLoaded(onDomElementFoundCB);
     return;
   }
 
@@ -138,13 +136,13 @@ function waitForDOMElement(elementId, success, fail, retriesLeft) {
 
   if (!element) {
     setTimeout(function () {
-      waitForDOMElement(elementId, success, fail, retriesLeft - 1);
+      waitForDOMElement(elementId, onDomElementFoundCB, retriesLeft - 1);
     }, 200);
     return;
   }
 
-  if (success && typeof success === 'function') {
-    success();
+  if (onDomElementFoundCB && typeof onDomElementFoundCB === 'function') {
+    onDomElementFoundCB();
   }
 }
 
@@ -282,9 +280,6 @@ window.__cbapi = function (command, version, callback, parameter) {
         function () {
           showConsentBanner(parameter, callback);
         },
-        loadOnDOMContentLoaded(function () {
-          showConsentBanner(parameter, callback);
-        }),
         3,
       );
       break;

--- a/src/templates/banner.js
+++ b/src/templates/banner.js
@@ -125,6 +125,7 @@ function loadOnDOMContentLoaded(domContentLoadedCB) {
 
 function waitForDOMElement(elementId, onDomElementFoundCB, retriesLeft) {
   if (retriesLeft < 0) {
+    // After retry attempts have been exhausted we try to use the DOMContentLoaded event as a fallback
     loadOnDOMContentLoaded(onDomElementFoundCB);
     return;
   }

--- a/src/templates/cmp.js
+++ b/src/templates/cmp.js
@@ -109,8 +109,19 @@
     return iframe;
   }
 
+  function loadOnDomContentLoad() {
+    window.addEventListener('DOMContentLoaded', function () {
+      if (isIframeCapable()) {
+        loadIframe(3);
+      } else {
+        loadCmpApi(3);
+      }
+    });
+  }
+
   function loadIframe(retriesLeft) {
     if (retriesLeft < 0) {
+      loadOnDomContentLoad();
       return;
     }
 
@@ -163,6 +174,7 @@
 
   function loadCmpApi(retriesLeft) {
     if (retriesLeft < 0) {
+      loadOnDomContentLoad();
       return;
     }
 

--- a/src/templates/cmp.js
+++ b/src/templates/cmp.js
@@ -187,8 +187,12 @@
   function init() {
     var waitForDOMElementRetries = 3;
     if (isIframeCapable()) {
+      // in case of iframe handling, we need to wait for the body element to be available,
+      // as the iframe is mounted to the body
       waitForDOMElement('body', loadIframe, waitForDOMElementRetries);
     } else {
+      // in case of non-iframe handling, the cmp is loaded with a script tag, therefore
+      // we need to check for the head to be available, where the script tag is written to
       waitForDOMElement('head', loadCmpApi, waitForDOMElementRetries);
     }
   }

--- a/src/templates/cmp.js
+++ b/src/templates/cmp.js
@@ -119,7 +119,7 @@
     });
   }
 
-  function waitForDomElement(elementTagName, success, fail, retriesLeft) {
+  function waitForDOMElement(elementTagName, success, fail, retriesLeft) {
     if (retriesLeft < 0) {
       if (fail && typeof fail === 'function') {
         fail();
@@ -131,7 +131,7 @@
 
     if (!element) {
       setTimeout(function () {
-        waitForDomElement(elementTagName, success, fail, retriesLeft - 1);
+        waitForDOMElement(elementTagName, success, fail, retriesLeft - 1);
       }, 200);
       return;
     }
@@ -189,9 +189,9 @@
   }
 
   if (isIframeCapable()) {
-    waitForDomElement('body', loadIframe, loadOnDOMContentLoaded, 3);
+    waitForDOMElement('body', loadIframe, loadOnDOMContentLoaded, 3);
   } else {
-    waitForDomElement('head', loadCmpApi, loadOnDOMContentLoaded, 3);
+    waitForDOMElement('head', loadCmpApi, loadOnDOMContentLoaded, 3);
   }
 
   // send device ids

--- a/src/templates/cmp.js
+++ b/src/templates/cmp.js
@@ -110,7 +110,7 @@
   }
 
   function loadOnDomContentLoad() {
-    window.addEventListener('DOMContentLoaded', function () {
+    document.addEventListener('DOMContentLoaded', function () {
       if (isIframeCapable()) {
         loadIframe(3);
       } else {


### PR DESCRIPTION
In case of e.g. a slow internet connection and/or devices with low processing power, it can happen that the body cannot be found within the 400ms the `cmp.js` scripts try to inject the necessary code to run the CMP.

This PR introduces an additional method, that in case the existing retry logic fails, the `cmp.js` loader script waits for the `DOMContentLoaded` event, and only then initialises the CMP.

The same mechanism is also introduced for showing the banner.