### PR TITLE
Handling of consent for additional channels

### DIFF
--- a/spec/debug-api.spec.js
+++ b/spec/debug-api.spec.js
@@ -62,7 +62,7 @@ describe("Debug API", () => {
         expect(queue).toHaveLength(2);
         expect(queue[1]).toEqual({
           event: "getTCData",
-          parameters: { status: "disabled" },
+          parameters: { consent: "undefined", consentAdditionalChannels: "undefined", status: "disabled" },
           success: true,
           ts: expect.any(Number),
         });
@@ -126,13 +126,13 @@ describe("Debug API", () => {
           expect(queue).toHaveLength(5);
           expect(queue[3]).toEqual({
             event: "getTCData",
-            parameters: { status: "disabled", consent: false },
+            parameters: { status: "disabled", consent: false, consentAdditionalChannels: false },
             success: true,
             ts: expect.any(Number),
           });
           expect(queue[4]).toEqual({
             event: "getTCData",
-            parameters: { status: "disabled", consent: false },
+            parameters: { status: "disabled", consent: false, consentAdditionalChannels: false },
             success: true,
             ts: expect.any(Number),
           });

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -5,6 +5,9 @@ export const HTTP_HOST = new EnvVar("HTTP_HOST").getStringOrFail();
 export const API_VERSION = new EnvVar("API_VERSION").getStringOrFail();
 export const COOKIE_DOMAIN = new EnvVar("COOKIE_DOMAIN").getStringOrFail();
 export const COOKIE_NAME = new EnvVar("COOKIE_NAME").getStringOrDefault("xconsent");
+export const COOKIE_NAME_ADDITIONAL_CHANNELS = new EnvVar("COOKIE_NAME_ADDITIONAL_CHANNELS").getStringOrDefault(
+  "xconsent_additional",
+);
 export const COOKIE_MAXAGE = new EnvVar("COOKIE_MAXAGE").getNumberOrDefault(
   1000 * 60 * 60 * 24 * 365 * 2, // 2 years
 );

--- a/src/controller/iframe.ts
+++ b/src/controller/iframe.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
 
-import { API_VERSION, HTTP_HOST, TECH_COOKIE_NAME, COOKIE_NAME } from "../config";
+import { API_VERSION, HTTP_HOST, TECH_COOKIE_NAME, COOKIE_NAME, COOKIE_NAME_ADDITIONAL_CHANNELS } from "../config";
 
 export const iframeController = (req: Request, res: Response) => {
   res.setHeader("Content-Type", "text/html");
@@ -10,6 +10,7 @@ export const iframeController = (req: Request, res: Response) => {
     TECH_COOKIE_TIMESTAMP: req.timestamp,
     TECH_COOKIE_NAME,
     COOKIE_NAME,
+    COOKIE_NAME_ADDITIONAL_CHANNELS,
     API_VERSION,
     CONSENT_SERVER_HOST: HTTP_HOST,
     CONSENT_SERVER_PROTOCOL: req.protocol,

--- a/src/controller/removeConsent.ts
+++ b/src/controller/removeConsent.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
 
-import { COOKIE_DOMAIN, COOKIE_NAME } from "../config";
+import { COOKIE_DOMAIN, COOKIE_NAME, COOKIE_NAME_ADDITIONAL_CHANNELS } from "../config";
 import { consentCounterMetric } from "../util/metrics";
 
 const img = Buffer.from(
@@ -15,6 +15,11 @@ export const removeConsentController = (req: Request, res: Response) => {
     maxAge: 0,
     domain: COOKIE_DOMAIN,
   });
+  res.cookie(COOKIE_NAME_ADDITIONAL_CHANNELS, "{}", {
+    maxAge: 0,
+    domain: COOKIE_DOMAIN,
+  });
+
   res.setHeader("Cache-Control", "no-store");
   res.setHeader("Content-Type", "image/png");
   res.setHeader("Content-Length", img.length);

--- a/src/controller/setConsent.ts
+++ b/src/controller/setConsent.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
 
-import { COOKIE_DOMAIN, COOKIE_NAME, COOKIE_MAXAGE } from "../config";
+import { COOKIE_DOMAIN, COOKIE_NAME, COOKIE_MAXAGE, COOKIE_NAME_ADDITIONAL_CHANNELS } from "../config";
 import { consentCounterMetric } from "../util/metrics";
 import { ConsentCookie } from "./util/getTemplateValues";
 
@@ -22,6 +22,11 @@ export const setConsentController = (req: Request, res: Response) => {
     .inc();
 
   res.cookie(COOKIE_NAME, Buffer.from(JSON.stringify(cookie)).toString("base64"), {
+    maxAge: COOKIE_MAXAGE,
+    domain: COOKIE_DOMAIN,
+  });
+
+  res.cookie(COOKIE_NAME_ADDITIONAL_CHANNELS, Buffer.from(JSON.stringify(cookie)).toString("base64"), {
     maxAge: COOKIE_MAXAGE,
     domain: COOKIE_DOMAIN,
   });

--- a/src/templates/cmpapi.js
+++ b/src/templates/cmpapi.js
@@ -4,6 +4,10 @@ window.__cmpapi = function (command, version, callback, parameter) {
   var channelId = '<%-CHANNEL_ID%>';
 
   var hasConsent = '<%-TC_CONSENT%>' === 'undefined' ? undefined : '<%-TC_CONSENT%>' === 'true';
+  var hasConsentAdditionalChannels =
+    '<%-TC_CONSENT_ADDITIONAL_CHANNELS%>' === 'undefined'
+      ? undefined
+      : '<%-TC_CONSENT_ADDITIONAL_CHANNELS%>' === 'true';
 
   if (window.localStorage && localStorage.getItem) {
     var localStorageConsent = localStorage.getItem('<%-COOKIE_NAME%>');
@@ -12,6 +16,14 @@ window.__cmpapi = function (command, version, callback, parameter) {
     }
     if (localStorageConsent === 'false') {
       hasConsent = false;
+    }
+
+    var localStorageConsentAdditionalChannels = localStorage.getItem('<%-COOKIE_NAME_ADDITIONAL_CHANNELS%>');
+    if (localStorageConsentAdditionalChannels === 'true') {
+      hasConsentAdditionalChannels = true;
+    }
+    if (localStorageConsentAdditionalChannels === 'false') {
+      hasConsentAdditionalChannels = false;
     }
   }
 
@@ -65,20 +77,27 @@ window.__cmpapi = function (command, version, callback, parameter) {
           purpose: {
             consents: {
               4040: hasConsent,
+              4041: hasConsentAdditionalChannels,
             },
           },
           legitimateInterests: {
             consents: {
               4040: hasConsent,
+              4041: hasConsentAdditionalChannels,
             },
           },
           vendor: {
             consents: {
               4040: hasConsent,
+              4041: hasConsentAdditionalChannels,
             },
           },
         });
-      log(logEvents.GET_TC_DATA, true, { status: '<%-CMP_STATUS%>', consent: hasConsent });
+      log(logEvents.GET_TC_DATA, true, {
+        status: '<%-CMP_STATUS%>',
+        consent: hasConsent ?? 'undefined',
+        consentAdditionalChannels: hasConsentAdditionalChannels ?? 'undefined',
+      });
       break;
     case 'setConsent':
       localStorageAvailable = false;
@@ -91,6 +110,7 @@ window.__cmpapi = function (command, version, callback, parameter) {
 
       if (window.localStorage && localStorage.setItem) {
         localStorage.setItem('<%-COOKIE_NAME%>', parameter);
+        localStorage.setItem('<%-COOKIE_NAME_ADDITIONAL_CHANNELS%>', parameter);
         localStorageAvailable = true;
       }
 
@@ -113,6 +133,7 @@ window.__cmpapi = function (command, version, callback, parameter) {
       image.src = '<%-CONSENT_SERVER_PROTOCOL%>://<%-CONSENT_SERVER_HOST%>/<%-API_VERSION%>/remove-consent';
       if (window.localStorage && localStorage.removeItem) {
         localStorage.removeItem('<%-COOKIE_NAME%>');
+        localStorage.removeItem('<%-COOKIE_NAME_ADDITIONAL_CHANNELS%>');
         localStorageAvailable = true;
       }
 

--- a/src/templates/iframe.html
+++ b/src/templates/iframe.html
@@ -12,6 +12,7 @@
 
       var techCookieTimestamp = '<%-TECH_COOKIE_TIMESTAMP%>';
       var hasConsent = null;
+      var hasConsentAdditionalChannels = null;
 
       if (window.localStorage && localStorage.getItem && localStorage.setItem) {
         if (!localStorage.getItem('<%-TECH_COOKIE_NAME%>')) {
@@ -20,11 +21,12 @@
         } else {
           techCookieTimestamp = localStorage.getItem('<%-TECH_COOKIE_NAME%>'); // prefer tech info from localStorage
           hasConsent = localStorage.getItem('<%-COOKIE_NAME%>');
+          hasConsentAdditionalChannels = localStorage.getItem('<%-COOKIE_NAME_ADDITIONAL_CHANNELS%>')
         }
       }
 
       var cmpApiScriptTag = document.createElement('script');
-      cmpApiScriptTag.setAttribute('src', '<%-CONSENT_SERVER_PROTOCOL%>://<%-CONSENT_SERVER_HOST%>/<%-API_VERSION%>/cmpapi-iframe.js?<%-TECH_COOKIE_NAME%>=' + techCookieTimestamp + (hasConsent !== null ? '&consent=' + hasConsent : '') + (channelId !== '' ? '&channelId=' + channelId : ''));
+      cmpApiScriptTag.setAttribute('src', '<%-CONSENT_SERVER_PROTOCOL%>://<%-CONSENT_SERVER_HOST%>/<%-API_VERSION%>/cmpapi-iframe.js?<%-TECH_COOKIE_NAME%>=' + techCookieTimestamp + (hasConsent !== null ? '&consent=' + hasConsent : '') + (hasConsentAdditionalChannels !== null ? '&consentAdditionalChannels=' + hasConsentAdditionalChannels : '') + (channelId !== '' ? '&channelId=' + channelId : ''));
       cmpApiScriptTag.setAttribute('type', 'text/javascript');
       document.getElementsByTagName('head')[0].appendChild(cmpApiScriptTag);
     } catch (e) { }


### PR DESCRIPTION
As newly added channels will need a separate consent for tracking, we added a new ID 4041 to check the consent decisions for these new channels separately.

Calling `setConsent` now saves the consent decision for both IDs, 4040 and 4041. But by checking if there was already a consent given for 4041, we can differentiate if only the consent for the pre-existing channels was given, or if there is already consent for the new set of channels.