### PR TITLE
Add build-specific cache busting param

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -37,6 +37,8 @@ jobs:
       - name: Build app
         id: build
         run: yarn build
+        env:
+          CACHE_BUSTING_PARAM: ${{ github.run_number }}
 
       - name: Test app
         id: test

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -38,7 +38,7 @@ jobs:
         id: build
         run: yarn build
         env:
-          CACHE_BUSTING_PARAM: ${{ github.run_number }}
+          BUILD_NUMBER: ${{ github.run_number }}
 
       - name: Test app
         id: test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,6 +36,8 @@ jobs:
       - name: Build app
         id: build
         run: yarn build
+        env:
+          CACHE_BUSTING_PARAM: ${{ github.run_number }}
 
       - name: Test app
         id: test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
         id: build
         run: yarn build
         env:
-          CACHE_BUSTING_PARAM: ${{ github.run_number }}
+          BUILD_NUMBER: ${{ github.run_number }}
 
       - name: Test app
         id: test

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -85,6 +85,9 @@ export default [
     languageOptions: {
       ecmaVersion: "latest",
       sourceType: "module",
+      globals: {
+        ...globals.node,
+      },
     },
   },
   {

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -6,7 +6,7 @@ import stringReplace from "gulp-string-replace";
 import terser from "gulp-terser";
 import ts from "gulp-typescript";
 
-var { CACHE_BUSTING_PARAM } = process.env;
+var { BUILD_NUMBER } = process.env;
 
 var tsProject = ts.createProject("tsconfig.json");
 
@@ -45,7 +45,7 @@ function copyTemplates() {
 function setSourceHashParam() {
   return gulp
     .src("./dist/templates/*")
-    .pipe(stringReplace("<%-CACHE_BUSTING_PARAM%>", CACHE_BUSTING_PARAM ?? ""))
+    .pipe(stringReplace("<%-BUILD_NUMBER%>", BUILD_NUMBER ?? ""))
     .pipe(gulp.dest("./dist/templates"));
 }
 

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -2,8 +2,11 @@ import gulp from "gulp";
 import htmlmin from "gulp-htmlmin";
 import minifyInline from "gulp-minify-inline";
 import sourcemaps from "gulp-sourcemaps";
+import stringReplace from "gulp-string-replace";
 import terser from "gulp-terser";
 import ts from "gulp-typescript";
+
+var { CACHE_BUSTING_PARAM } = process.env;
 
 var tsProject = ts.createProject("tsconfig.json");
 
@@ -39,6 +42,13 @@ function copyTemplates() {
   return gulp.src("./src/templates/*").pipe(gulp.dest("./dist/templates"));
 }
 
+function setSourceHashParam() {
+  return gulp
+    .src("./dist/templates/*")
+    .pipe(stringReplace("<%-CACHE_BUSTING_PARAM%>", CACHE_BUSTING_PARAM ?? ""))
+    .pipe(gulp.dest("./dist/templates"));
+}
+
 function minifyJsTemplates() {
   return gulp.src("./dist/templates/*.js").pipe(terser(terserOptions)).pipe(gulp.dest("./dist/templates"));
 }
@@ -51,4 +61,4 @@ function minifyHtmlTemplates() {
     .pipe(gulp.dest("./dist/templates"));
 }
 
-export default gulp.series(typescript, copyTemplates, minifyJsTemplates, minifyHtmlTemplates);
+export default gulp.series(typescript, copyTemplates, setSourceHashParam, minifyJsTemplates, minifyHtmlTemplates);

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "gulp-htmlmin": "^5.0.1",
     "gulp-minify-inline": "^1.1.0",
     "gulp-sourcemaps": "^3.0.0",
+    "gulp-string-replace": "^1.1.2",
     "gulp-terser": "^2.1.0",
     "gulp-typescript": "^6.0.0-alpha.1",
     "jest": "^29.3.1",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -13,6 +13,7 @@ export const TECH_COOKIE_NAME = new EnvVar("TECH_COOKIE_NAME").getStringOrDefaul
 export const TECH_COOKIE_MIN = new EnvVar("TECH_COOKIE_MIN").getNumberOrDefault(
   1000 * 60 * 60 * 24 * 2, // 2 days
 );
+export const CACHE_BUSTING_PARAM = new EnvVar("CACHE_BUSTING_PARAM").getString();
 export const CMP_ENABLED_SAMPLING_THRESHOLD_PERCENT = new EnvVar(
   "CMP_ENABLED_SAMPLING_THRESHOLD_PERCENT",
 ).getNumberOrDefault(15);

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -13,7 +13,7 @@ export const TECH_COOKIE_NAME = new EnvVar("TECH_COOKIE_NAME").getStringOrDefaul
 export const TECH_COOKIE_MIN = new EnvVar("TECH_COOKIE_MIN").getNumberOrDefault(
   1000 * 60 * 60 * 24 * 2, // 2 days
 );
-export const CACHE_BUSTING_PARAM = new EnvVar("CACHE_BUSTING_PARAM").getString();
+export const BUILD_NUMBER = new EnvVar("BUILD_NUMBER").getString();
 export const CMP_ENABLED_SAMPLING_THRESHOLD_PERCENT = new EnvVar(
   "CMP_ENABLED_SAMPLING_THRESHOLD_PERCENT",
 ).getNumberOrDefault(15);

--- a/src/controller/banner.ts
+++ b/src/controller/banner.ts
@@ -5,7 +5,7 @@ import { logger } from "../util/logger";
 
 export const bannerController = async (req: Request, res: Response) => {
   res.setHeader("Content-Type", "application/javascript");
-  res.setHeader("Cache-Control", "public, max-age=3600");
+  res.setHeader("Cache-Control", "public, max-age=3600, s-maxage=300");
 
   try {
     res.render("banner.js", {

--- a/src/controller/cmp.ts
+++ b/src/controller/cmp.ts
@@ -1,11 +1,11 @@
 import { Request, Response } from "express";
 
-import { API_VERSION, HTTP_HOST } from "../config";
+import { API_VERSION, HTTP_HOST, CACHE_BUSTING_PARAM } from "../config";
 import { loadedCounterMetric } from "../util/metrics";
 
 export const cmpController = async (req: Request, res: Response) => {
   res.setHeader("Content-Type", "application/javascript");
-  res.setHeader("Cache-Control", "public, max-age=3600");
+  res.setHeader("Cache-Control", "public, max-age=3600, s-maxage=300");
 
   loadedCounterMetric.labels({ channel: req.channelName }).inc();
 
@@ -14,6 +14,7 @@ export const cmpController = async (req: Request, res: Response) => {
       VERSION_PATH: API_VERSION ? `/${API_VERSION}/` : "/",
       CONSENT_SERVER_HOST: HTTP_HOST,
       CHANNEL_ID: req.channelId,
+      CACHE_BUSTING_PARAM,
     });
   } catch (e) {
     res.status(500).send(e);

--- a/src/controller/cmp.ts
+++ b/src/controller/cmp.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
 
-import { API_VERSION, HTTP_HOST, CACHE_BUSTING_PARAM } from "../config";
+import { API_VERSION, HTTP_HOST, BUILD_NUMBER } from "../config";
 import { loadedCounterMetric } from "../util/metrics";
 
 export const cmpController = async (req: Request, res: Response) => {
@@ -14,7 +14,7 @@ export const cmpController = async (req: Request, res: Response) => {
       VERSION_PATH: API_VERSION ? `/${API_VERSION}/` : "/",
       CONSENT_SERVER_HOST: HTTP_HOST,
       CHANNEL_ID: req.channelId,
-      CACHE_BUSTING_PARAM,
+      BUILD_NUMBER,
     });
   } catch (e) {
     res.status(500).send(e);

--- a/src/controller/cmpWithTracking.ts
+++ b/src/controller/cmpWithTracking.ts
@@ -2,7 +2,14 @@ import { renderFile } from "ejs";
 import { Request, Response } from "express";
 import path from "path";
 
-import { API_VERSION, HTTP_HOST, BUILD_NUMBER, TRACKING_HOST_CONSENT, TRACKING_HOST_NO_CONSENT, TRACKING_VERSION } from "../config";
+import {
+  API_VERSION,
+  HTTP_HOST,
+  BUILD_NUMBER,
+  TRACKING_HOST_CONSENT,
+  TRACKING_HOST_NO_CONSENT,
+  TRACKING_VERSION,
+} from "../config";
 
 export const cmpWithTrackingController = async (req: Request, res: Response) => {
   if (req.channelId === undefined) {

--- a/src/controller/cmpWithTracking.ts
+++ b/src/controller/cmpWithTracking.ts
@@ -5,7 +5,7 @@ import path from "path";
 import {
   API_VERSION,
   HTTP_HOST,
-  CACHE_BUSTING_PARAM,
+  BUILD_NUMBER,
   TRACKING_HOST_CONSENT,
   TRACKING_HOST_NO_CONSENT,
 } from "../config";
@@ -29,7 +29,7 @@ export const cmpWithTrackingController = async (req: Request, res: Response) => 
       VERSION_PATH: API_VERSION ? `/${API_VERSION}/` : "/",
       CONSENT_SERVER_HOST: HTTP_HOST,
       CHANNEL_ID: req.channelId,
-      CACHE_BUSTING_PARAM,
+      BUILD_NUMBER,
     });
     const trackingJs = await renderFile(path.join(__dirname, "../templates/cmpWithTracking.js"), {
       CHANNEL_ID: req.channelId,

--- a/src/controller/cmpWithTracking.ts
+++ b/src/controller/cmpWithTracking.ts
@@ -2,13 +2,7 @@ import { renderFile } from "ejs";
 import { Request, Response } from "express";
 import path from "path";
 
-import {
-  API_VERSION,
-  HTTP_HOST,
-  BUILD_NUMBER,
-  TRACKING_HOST_CONSENT,
-  TRACKING_HOST_NO_CONSENT,
-} from "../config";
+import { API_VERSION, HTTP_HOST, BUILD_NUMBER, TRACKING_HOST_CONSENT, TRACKING_HOST_NO_CONSENT } from "../config";
 
 export const cmpWithTrackingController = async (req: Request, res: Response) => {
   if (req.channelId === undefined) {

--- a/src/controller/cmpWithTracking.ts
+++ b/src/controller/cmpWithTracking.ts
@@ -2,7 +2,13 @@ import { renderFile } from "ejs";
 import { Request, Response } from "express";
 import path from "path";
 
-import { API_VERSION, HTTP_HOST, TRACKING_HOST_CONSENT, TRACKING_HOST_NO_CONSENT } from "../config";
+import {
+  API_VERSION,
+  HTTP_HOST,
+  CACHE_BUSTING_PARAM,
+  TRACKING_HOST_CONSENT,
+  TRACKING_HOST_NO_CONSENT,
+} from "../config";
 
 export const cmpWithTrackingController = async (req: Request, res: Response) => {
   if (req.channelId === undefined) {
@@ -16,13 +22,14 @@ export const cmpWithTrackingController = async (req: Request, res: Response) => 
   }
 
   res.setHeader("Content-Type", "application/javascript");
-  res.setHeader("Cache-Control", "public, max-age=3600");
+  res.setHeader("Cache-Control", "public, max-age=3600, s-maxage=300");
 
   try {
     const cmpJs = await renderFile(path.join(__dirname, "../templates/cmp.js"), {
       VERSION_PATH: API_VERSION ? `/${API_VERSION}/` : "/",
       CONSENT_SERVER_HOST: HTTP_HOST,
       CHANNEL_ID: req.channelId,
+      CACHE_BUSTING_PARAM,
     });
     const trackingJs = await renderFile(path.join(__dirname, "../templates/cmpWithTracking.js"), {
       CHANNEL_ID: req.channelId,

--- a/src/controller/cmpapi.ts
+++ b/src/controller/cmpapi.ts
@@ -16,7 +16,7 @@ import {
 
 export const cmpapiController = async (req: Request, res: Response) => {
   res.setHeader("Content-Type", "application/javascript");
-  res.setHeader("Cache-Control", "public, max-age=3600");
+  res.setHeader("Cache-Control", "public, max-age=3600, s-maxage=300");
 
   const channelId = req.query.channelId?.toString();
   const disabledChannelIds = CMP_DISABLED_CHANNEL_IDS?.split(",").map((channelId) => channelId.trim());

--- a/src/controller/iframe.ts
+++ b/src/controller/iframe.ts
@@ -1,14 +1,15 @@
 import { Request, Response } from "express";
 
-import { API_VERSION, HTTP_HOST } from "../config";
+import { API_VERSION, HTTP_HOST, CACHE_BUSTING_PARAM } from "../config";
 
 export const iframeController = (req: Request, res: Response) => {
   res.setHeader("Content-Type", "text/html");
-  res.setHeader("Cache-Control", "public, max-age=3600");
+  res.setHeader("Cache-Control", "public, max-age=3600, s-maxage=300");
 
   res.render("iframe.html", {
     VERSION_PATH: API_VERSION ? `/${API_VERSION}/` : "/",
     CONSENT_SERVER_HOST: HTTP_HOST,
     CHANNEL_ID: req.channelId,
+    CACHE_BUSTING_PARAM,
   });
 };

--- a/src/controller/iframe.ts
+++ b/src/controller/iframe.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
 
-import { API_VERSION, HTTP_HOST, CACHE_BUSTING_PARAM } from "../config";
+import { API_VERSION, HTTP_HOST, BUILD_NUMBER } from "../config";
 
 export const iframeController = (req: Request, res: Response) => {
   res.setHeader("Content-Type", "text/html");
@@ -10,6 +10,6 @@ export const iframeController = (req: Request, res: Response) => {
     VERSION_PATH: API_VERSION ? `/${API_VERSION}/` : "/",
     CONSENT_SERVER_HOST: HTTP_HOST,
     CHANNEL_ID: req.channelId,
-    CACHE_BUSTING_PARAM,
+    BUILD_NUMBER,
   });
 };

--- a/src/templates/cmp.js
+++ b/src/templates/cmp.js
@@ -44,6 +44,7 @@
   }
 
   var channelId = '<%-CHANNEL_ID%>';
+  var cacheBustingParam = '<%-CACHE_BUSTING_PARAM%>';
 
   function isIframeCapable() {
     var excludeList = ['antgalio', 'hybrid', 'maple', 'presto', 'technotrend goerler', 'viera 2011'];
@@ -85,14 +86,13 @@
   }
 
   function createIframe() {
-    var iframe = document.createElement('iframe');
+    var q = '';
+    q = q + (channelId !== '' ? '&channelId=' + channelId : '');
+    q = q + (cacheBustingParam !== '' ? '&v=' + cacheBustingParam : '');
+    q = q.length ? '?' + q.substring(1) : '';
 
-    iframe.setAttribute(
-      'src',
-      window.location.protocol +
-        '//<%-CONSENT_SERVER_HOST%><%-VERSION_PATH%>iframe.html' +
-        (channelId !== '' ? '?channelId=' + channelId : '')
-    );
+    var iframe = document.createElement('iframe');
+    iframe.setAttribute('src', window.location.protocol + '//<%-CONSENT_SERVER_HOST%><%-VERSION_PATH%>iframe.html' + q);
     iframe.setAttribute('style', 'position:fixed;border:0;outline:0;top:-999px;left:-999px;width:0;height:0;');
     iframe.setAttribute('frameborder', '0');
 
@@ -154,13 +154,16 @@
   }
 
   function createCmpApiScriptTag() {
+    var q = '';
+    q = q + (channelId !== '' ? '&channelId=' + channelId : '');
+    q = q + (cacheBustingParam !== '' ? '&h=' + cacheBustingParam : '');
+    q = q.length ? '?' + q.substring(1) : '';
+
     var cmpapiScriptTag = document.createElement('script');
     cmpapiScriptTag.setAttribute('type', 'text/javascript');
     cmpapiScriptTag.setAttribute(
       'src',
-      window.location.protocol +
-        '//<%-CONSENT_SERVER_HOST%><%-VERSION_PATH%>cmpapi.js' +
-        (channelId !== '' ? '?channelId=' + channelId : '')
+      window.location.protocol + '//<%-CONSENT_SERVER_HOST%><%-VERSION_PATH%>cmpapi.js' + q
     );
 
     cmpapiScriptTag.onload = function () {

--- a/src/templates/cmp.js
+++ b/src/templates/cmp.js
@@ -44,7 +44,7 @@
   }
 
   var channelId = '<%-CHANNEL_ID%>';
-  var cacheBustingParam = '<%-CACHE_BUSTING_PARAM%>';
+  var buildNumber = '<%-BUILD_NUMBER%>';
 
   function isIframeCapable() {
     var excludeList = ['antgalio', 'hybrid', 'maple', 'presto', 'technotrend goerler', 'viera 2011'];
@@ -88,7 +88,7 @@
   function createIframe() {
     var q = '';
     q = q + (channelId !== '' ? '&channelId=' + channelId : '');
-    q = q + (cacheBustingParam !== '' ? '&v=' + cacheBustingParam : '');
+    q = q + (buildNumber !== '' ? '&v=' + buildNumber : '');
     q = q.length ? '?' + q.substring(1) : '';
 
     var iframe = document.createElement('iframe');
@@ -156,7 +156,7 @@
   function createCmpApiScriptTag() {
     var q = '';
     q = q + (channelId !== '' ? '&channelId=' + channelId : '');
-    q = q + (cacheBustingParam !== '' ? '&h=' + cacheBustingParam : '');
+    q = q + (buildNumber !== '' ? '&h=' + buildNumber : '');
     q = q.length ? '?' + q.substring(1) : '';
 
     var cmpapiScriptTag = document.createElement('script');

--- a/src/templates/iframe.html
+++ b/src/templates/iframe.html
@@ -43,11 +43,11 @@
 
     try {
       var channelId = '<%-CHANNEL_ID%>';
-      var cacheBustingParam = '<%-CACHE_BUSTING_PARAM%>';
+      var buildNumber = '<%-BUILD_NUMBER%>';
 
       var q = '';
       q = q + (channelId !== '' ? '&channelId=' + channelId : '');
-      q = q + (cacheBustingParam !== '' ? '&v=' + cacheBustingParam : '');
+      q = q + (buildNumber !== '' ? '&v=' + buildNumber : '');
       q = q.length ? '?' + q.substring(1) : '';
 
       var cmpApiScriptTag = document.createElement('script');

--- a/src/templates/iframe.html
+++ b/src/templates/iframe.html
@@ -43,8 +43,15 @@
 
     try {
       var channelId = '<%-CHANNEL_ID%>';
+      var cacheBustingParam = '<%-CACHE_BUSTING_PARAM%>';
+
+      var q = '';
+      q = q + (channelId !== '' ? '&channelId=' + channelId : '');
+      q = q + (cacheBustingParam !== '' ? '&v=' + cacheBustingParam : '');
+      q = q.length ? '?' + q.substring(1) : '';
+
       var cmpApiScriptTag = document.createElement('script');
-      cmpApiScriptTag.setAttribute('src', window.location.protocol + '//<%-CONSENT_SERVER_HOST%><%-VERSION_PATH%>cmpapi.js' + (channelId !== '' ? '?channelId=' + channelId : ''));
+      cmpApiScriptTag.setAttribute('src', window.location.protocol + '//<%-CONSENT_SERVER_HOST%><%-VERSION_PATH%>cmpapi.js' + q);
       cmpApiScriptTag.setAttribute('type', 'text/javascript');
       document.getElementsByTagName('head')[0].appendChild(cmpApiScriptTag);
     } catch (e) { }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1265,6 +1265,13 @@ ansi-escapes@^4.2.1:
   dependencies:
     type-fest "^0.21.3"
 
+ansi-gray@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-gray/-/ansi-gray-0.1.1.tgz#2962cf54ec9792c48510a3deb524436861ef7251"
+  integrity sha512-HrgGIZUl8h2EHuZaU9hTR/cU5nhKxpVE1V6kdGsQ8e4zirElJ5fvtfc8N7Q1oq1aatO275i8pUFUCpNWCAnVWw==
+  dependencies:
+    ansi-wrap "0.1.0"
+
 ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
@@ -1289,7 +1296,7 @@ ansi-styles@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
-ansi-wrap@^0.1.0:
+ansi-wrap@0.1.0, ansi-wrap@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/ansi-wrap/-/ansi-wrap-0.1.0.tgz#a82250ddb0015e9a27ca82e82ea603bbfa45efaf"
   integrity sha512-ZyznvL8k/FZeQHr2T6LzcJ/+vBApDnMNZvfVFy3At0knswWd6rJ3/0Hhmpu8oqa6C92npmozs890sX9Dl6q+Qw==
@@ -2138,7 +2145,7 @@ caniuse-lite@^1.0.30001646:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001655.tgz#0ce881f5a19a2dcfda2ecd927df4d5c1684b982f"
   integrity sha512-jRGVy3iSGO5Uutn2owlb5gR6qsGngTw9ZTb4ali9f3glshcNmJ2noam4Mo9zia5P9Dk3jNNydy7vQjuE5dQmfg==
 
-chalk@^2.4.2:
+chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -2358,6 +2365,11 @@ color-string@^1.6.0:
   dependencies:
     color-name "^1.0.0"
     simple-swizzle "^0.2.2"
+
+color-support@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
+  integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
 
 color@^3.1.3:
   version "3.2.1"
@@ -3317,7 +3329,7 @@ escape-html@~1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
 
-escape-string-regexp@^1.0.5:
+escape-string-regexp@^1.0.3, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==
@@ -3675,7 +3687,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@^3.0.0, extend@^3.0.2:
+extend@^3.0.0, extend@^3.0.1, extend@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
@@ -3711,6 +3723,16 @@ extract-zip@^2.0.1:
     yauzl "^2.10.0"
   optionalDependencies:
     "@types/yauzl" "^2.9.1"
+
+fancy-log@^1.3.2:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/fancy-log/-/fancy-log-1.3.3.tgz#dbc19154f558690150a23953a0adbd035be45fc7"
+  integrity sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==
+  dependencies:
+    ansi-gray "^0.1.1"
+    color-support "^1.1.3"
+    parse-node-version "^1.0.0"
+    time-stamp "^1.0.0"
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -4336,6 +4358,18 @@ gulp-sourcemaps@^3.0.0:
     source-map "^0.6.0"
     strip-bom-string "^1.0.0"
     through2 "^2.0.0"
+
+gulp-string-replace@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/gulp-string-replace/-/gulp-string-replace-1.1.2.tgz#26e646ae1201954d07cce9172ed25efbcd01d171"
+  integrity sha512-8T0eE2SIKPxhG4YNgVM6SEoKRXKh4mRgNT3N/0zXLBGTN4y/E9Y+TR+1gDCrqi431RNkS6ZeLlJ24rKNrdVzYQ==
+  dependencies:
+    chalk "^2.4.1"
+    extend "^3.0.1"
+    fancy-log "^1.3.2"
+    plugin-error "^1.0.1"
+    replacestream "^4.0.3"
+    through2 "^2.0.3"
 
 gulp-terser@^2.1.0:
   version "2.1.0"
@@ -6241,7 +6275,7 @@ nth-check@~1.0.1:
   dependencies:
     boolbase "~1.0.0"
 
-object-assign@4.X, object-assign@^4:
+object-assign@4.X, object-assign@^4, object-assign@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
@@ -6515,6 +6549,11 @@ parse-json@^5.2.0:
     error-ex "^1.3.1"
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
+
+parse-node-version@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parse-node-version/-/parse-node-version-1.0.1.tgz#e2b5dbede00e7fa9bc363607f53327e8b073189b"
+  integrity sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==
 
 parse-passwd@^1.0.0:
   version "1.0.0"
@@ -7064,6 +7103,15 @@ replace-homedir@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/replace-homedir/-/replace-homedir-2.0.0.tgz#245bd9c909275e0beee75eae85bb40780cd61903"
   integrity sha512-bgEuQQ/BHW0XkkJtawzrfzHFSN70f/3cNOiHa2QsYxqrjaC30X1k74FJ6xswVBP0sr0SpGIdVFuPwfrYziVeyw==
+
+replacestream@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/replacestream/-/replacestream-4.0.3.tgz#3ee5798092be364b1cdb1484308492cb3dff2f36"
+  integrity sha512-AC0FiLS352pBBiZhd4VXB1Ab/lh0lEgpP+GGvZqbQh8a5cmXVoTe5EX/YeTFArnp4SRGTHh1qCHu9lGs1qG8sA==
+  dependencies:
+    escape-string-regexp "^1.0.3"
+    object-assign "^4.0.1"
+    readable-stream "^2.0.2"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -7951,6 +7999,11 @@ through@2, "through@>=2.2.7 <3", through@^2.3.8, through@~2.3, through@~2.3.1:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
+
+time-stamp@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/time-stamp/-/time-stamp-1.1.0.tgz#764a5a11af50561921b133f3b44e618687e0f5c3"
+  integrity sha512-gLCeArryy2yNTRzTGKbZbloctj64jkZ57hj5zdraXue6aFgd6PmvVtEyiUU+hvU0v7q08oVv8r8ev0tRo6bvgw==
 
 timers-browserify@^1.0.1:
   version "1.4.2"


### PR DESCRIPTION
Changes in this PR:
* `s-maxage=300` added to `Cache-Control` header for CMP scripts
* introduced `CACHE_BUSTING_PARAM`, which is set in `cmp.js` and `iframe.html` on build-time and is appended to src when loading `iframe.html` and `cmpapi.js` templates. This ensures that the right child-templates for the loaded CMP version are loaded.