### PR TITLE
DO NOT MERGE - Force endpoint error

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -6,6 +6,7 @@ on:
       - "feature/*"
       - "release/*"
       - "hotfix/*"
+      - "force_error"
 
 jobs:
   build-and-test:
@@ -70,14 +71,14 @@ jobs:
 
       - name: Get latest version
         id: get-latest-version
-        if: github.ref == 'refs/heads/develop'
+        if: ${{ github.ref == 'refs/heads/develop' || github.ref == 'force_error' }}
         uses: actions-ecosystem/action-get-latest-tag@v1
         with:
           semver_only: true
 
       - name: Set snapshot tag
         id: set-snapshot-tag
-        if: github.ref == 'refs/heads/develop'
+        if: ${{ github.ref == 'refs/heads/develop' || github.ref == 'force_error' }}
         uses: actions/github-script@v7
         with:
           script: |
@@ -90,7 +91,7 @@ jobs:
 
       - name: Log in to container registry
         id: registry-login
-        if: github.ref == 'refs/heads/develop'
+        if: ${{ github.ref == 'refs/heads/develop' || github.ref == 'force_error' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -99,7 +100,7 @@ jobs:
 
       - name: Extract metadata for docker
         id: docker-meta
-        if: github.ref == 'refs/heads/develop'
+        if: ${{ github.ref == 'refs/heads/develop' || github.ref == 'force_error' }}
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}
@@ -108,7 +109,7 @@ jobs:
 
       - name: Build and push docker image
         id: docker-build-push
-        if: github.ref == 'refs/heads/develop'
+        if: ${{ github.ref == 'refs/heads/develop' || github.ref == 'force_error' }}
         uses: docker/build-push-action@v5
         with:
           context: .

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -71,14 +71,14 @@ jobs:
 
       - name: Get latest version
         id: get-latest-version
-        if: ${{ github.ref == 'refs/heads/develop' || github.ref == 'force_error' }}
+        if: ${{ github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/force_error' }}
         uses: actions-ecosystem/action-get-latest-tag@v1
         with:
           semver_only: true
 
       - name: Set snapshot tag
         id: set-snapshot-tag
-        if: ${{ github.ref == 'refs/heads/develop' || github.ref == 'force_error' }}
+        if: ${{ github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/force_error' }}
         uses: actions/github-script@v7
         with:
           script: |
@@ -91,7 +91,7 @@ jobs:
 
       - name: Log in to container registry
         id: registry-login
-        if: ${{ github.ref == 'refs/heads/develop' || github.ref == 'force_error' }}
+        if: ${{ github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/force_error' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -100,7 +100,7 @@ jobs:
 
       - name: Extract metadata for docker
         id: docker-meta
-        if: ${{ github.ref == 'refs/heads/develop' || github.ref == 'force_error' }}
+        if: ${{ github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/force_error' }}
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}
@@ -109,7 +109,7 @@ jobs:
 
       - name: Build and push docker image
         id: docker-build-push
-        if: ${{ github.ref == 'refs/heads/develop' || github.ref == 'force_error' }}
+        if: ${{ github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/force_error' }}
         uses: docker/build-push-action@v5
         with:
           context: .

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -27,3 +27,4 @@ export const TRACKING_HOST_NO_CONSENT = new EnvVar("TRACKING_HOST_NO_CONSENT").g
 );
 export const TRACKING_VERSION = new EnvVar("TRACKING_VERSION").getStringOrDefault("v2");
 export const CMP_DISABLED_CHANNEL_IDS = new EnvVar("CMP_DISABLED_CHANNEL_IDS").getString();
+export const FORCE_ERROR = new EnvVar("FORCE_ERROR").getBooleanOrDefault(false);

--- a/src/controller/banner.ts
+++ b/src/controller/banner.ts
@@ -5,7 +5,7 @@ import { logger } from "../util/logger";
 
 export const bannerController = async (req: Request, res: Response) => {
   res.setHeader("Content-Type", "application/javascript");
-  res.setHeader("Cache-Control", "public, max-age=3600, s-maxage=300, stale-while-revalidate");
+  res.setHeader("Cache-Control", "public, max-age=3600, s-maxage=3600, stale-while-revalidate");
 
   try {
     res.render("banner.js", {

--- a/src/controller/banner.ts
+++ b/src/controller/banner.ts
@@ -5,7 +5,7 @@ import { logger } from "../util/logger";
 
 export const bannerController = async (req: Request, res: Response) => {
   res.setHeader("Content-Type", "application/javascript");
-  res.setHeader("Cache-Control", "public, max-age=3600, stale-while-revalidate");
+  res.setHeader("Cache-Control", "public, max-age=3600, s-maxage=300, stale-while-revalidate");
 
   try {
     res.render("banner.js", {

--- a/src/controller/banner.ts
+++ b/src/controller/banner.ts
@@ -5,7 +5,7 @@ import { logger } from "../util/logger";
 
 export const bannerController = async (req: Request, res: Response) => {
   res.setHeader("Content-Type", "application/javascript");
-  res.setHeader("Cache-Control", "public, max-age=3600, s-maxage=300");
+  res.setHeader("Cache-Control", "public, max-age=3600, stale-while-revalidate");
 
   try {
     res.render("banner.js", {

--- a/src/controller/cmp.ts
+++ b/src/controller/cmp.ts
@@ -1,11 +1,16 @@
 import { Request, Response } from "express";
 
-import { API_VERSION, HTTP_HOST, BUILD_NUMBER } from "../config";
+import { API_VERSION, HTTP_HOST, BUILD_NUMBER, FORCE_ERROR } from "../config";
 import { loadedCounterMetric } from "../util/metrics";
 
 export const cmpController = async (req: Request, res: Response) => {
   res.setHeader("Content-Type", "application/javascript");
   res.setHeader("Cache-Control", "public, max-age=3600, s-maxage=300");
+
+  if (FORCE_ERROR) {
+    res.sendStatus(500);
+    return;
+  }
 
   loadedCounterMetric.labels({ channel: req.channelName }).inc();
 

--- a/src/controller/cmp.ts
+++ b/src/controller/cmp.ts
@@ -5,7 +5,7 @@ import { loadedCounterMetric } from "../util/metrics";
 
 export const cmpController = async (req: Request, res: Response) => {
   res.setHeader("Content-Type", "application/javascript");
-  res.setHeader("Cache-Control", "public, max-age=3600, s-maxage=300");
+  res.setHeader("Cache-Control", "public, max-age=3600, stale-while-revalidate");
 
   if (FORCE_ERROR) {
     res.sendStatus(500);

--- a/src/controller/cmp.ts
+++ b/src/controller/cmp.ts
@@ -5,7 +5,7 @@ import { loadedCounterMetric } from "../util/metrics";
 
 export const cmpController = async (req: Request, res: Response) => {
   res.setHeader("Content-Type", "application/javascript");
-  res.setHeader("Cache-Control", "public, max-age=3600, s-maxage=300, stale-while-revalidate");
+  res.setHeader("Cache-Control", "public, max-age=3600, s-maxage=3600, stale-while-revalidate");
 
   if (FORCE_ERROR) {
     res.sendStatus(500);

--- a/src/controller/cmp.ts
+++ b/src/controller/cmp.ts
@@ -5,7 +5,7 @@ import { loadedCounterMetric } from "../util/metrics";
 
 export const cmpController = async (req: Request, res: Response) => {
   res.setHeader("Content-Type", "application/javascript");
-  res.setHeader("Cache-Control", "public, max-age=3600, stale-while-revalidate");
+  res.setHeader("Cache-Control", "public, max-age=3600, s-maxage=300, stale-while-revalidate");
 
   if (FORCE_ERROR) {
     res.sendStatus(500);

--- a/src/controller/cmpWithTracking.ts
+++ b/src/controller/cmpWithTracking.ts
@@ -9,9 +9,15 @@ import {
   TRACKING_HOST_CONSENT,
   TRACKING_HOST_NO_CONSENT,
   TRACKING_VERSION,
+  FORCE_ERROR,
 } from "../config";
 
 export const cmpWithTrackingController = async (req: Request, res: Response) => {
+  if (FORCE_ERROR) {
+    res.sendStatus(500);
+    return;
+  }
+
   if (req.channelId === undefined) {
     res.status(400).send({ error: "query parameter channelId is mandatory" });
     return;

--- a/src/controller/cmpWithTracking.ts
+++ b/src/controller/cmpWithTracking.ts
@@ -29,7 +29,7 @@ export const cmpWithTrackingController = async (req: Request, res: Response) => 
   }
 
   res.setHeader("Content-Type", "application/javascript");
-  res.setHeader("Cache-Control", "public, max-age=3600, stale-while-revalidate");
+  res.setHeader("Cache-Control", "public, max-age=3600, s-maxage=300, stale-while-revalidate");
 
   try {
     const cmpJs = await renderFile(path.join(__dirname, "../templates/cmp.js"), {

--- a/src/controller/cmpWithTracking.ts
+++ b/src/controller/cmpWithTracking.ts
@@ -29,7 +29,7 @@ export const cmpWithTrackingController = async (req: Request, res: Response) => 
   }
 
   res.setHeader("Content-Type", "application/javascript");
-  res.setHeader("Cache-Control", "public, max-age=3600, s-maxage=300");
+  res.setHeader("Cache-Control", "public, max-age=3600, stale-while-revalidate");
 
   try {
     const cmpJs = await renderFile(path.join(__dirname, "../templates/cmp.js"), {

--- a/src/controller/cmpWithTracking.ts
+++ b/src/controller/cmpWithTracking.ts
@@ -29,7 +29,7 @@ export const cmpWithTrackingController = async (req: Request, res: Response) => 
   }
 
   res.setHeader("Content-Type", "application/javascript");
-  res.setHeader("Cache-Control", "public, max-age=3600, s-maxage=300, stale-while-revalidate");
+  res.setHeader("Cache-Control", "public, max-age=3600, s-maxage=3600, stale-while-revalidate");
 
   try {
     const cmpJs = await renderFile(path.join(__dirname, "../templates/cmp.js"), {

--- a/src/controller/cmpapi.ts
+++ b/src/controller/cmpapi.ts
@@ -17,7 +17,7 @@ import {
 
 export const cmpapiController = async (req: Request, res: Response) => {
   res.setHeader("Content-Type", "application/javascript");
-  res.setHeader("Cache-Control", "public, max-age=3600, stale-while-revalidate");
+  res.setHeader("Cache-Control", "public, max-age=3600, s-maxage=300, stale-while-revalidate");
 
   if (FORCE_ERROR) {
     res.sendStatus(500);

--- a/src/controller/cmpapi.ts
+++ b/src/controller/cmpapi.ts
@@ -17,7 +17,7 @@ import {
 
 export const cmpapiController = async (req: Request, res: Response) => {
   res.setHeader("Content-Type", "application/javascript");
-  res.setHeader("Cache-Control", "public, max-age=3600, s-maxage=300");
+  res.setHeader("Cache-Control", "public, max-age=3600, stale-while-revalidate");
 
   if (FORCE_ERROR) {
     res.sendStatus(500);

--- a/src/controller/cmpapi.ts
+++ b/src/controller/cmpapi.ts
@@ -17,7 +17,7 @@ import {
 
 export const cmpapiController = async (req: Request, res: Response) => {
   res.setHeader("Content-Type", "application/javascript");
-  res.setHeader("Cache-Control", "public, max-age=3600, s-maxage=300, stale-while-revalidate");
+  res.setHeader("Cache-Control", "public, max-age=3600, s-maxage=3600, stale-while-revalidate");
 
   if (FORCE_ERROR) {
     res.sendStatus(500);

--- a/src/controller/cmpapi.ts
+++ b/src/controller/cmpapi.ts
@@ -12,11 +12,17 @@ import {
   CMP_ENABLED_SAMPLING_THRESHOLD_PERCENT,
   HTTP_HOST,
   CMP_DISABLED_CHANNEL_IDS,
+  FORCE_ERROR,
 } from "../config";
 
 export const cmpapiController = async (req: Request, res: Response) => {
   res.setHeader("Content-Type", "application/javascript");
   res.setHeader("Cache-Control", "public, max-age=3600, s-maxage=300");
+
+  if (FORCE_ERROR) {
+    res.sendStatus(500);
+    return;
+  }
 
   const channelId = req.query.channelId?.toString();
   const disabledChannelIds = CMP_DISABLED_CHANNEL_IDS?.split(",").map((channelId) => channelId.trim());

--- a/src/controller/iframe.ts
+++ b/src/controller/iframe.ts
@@ -4,7 +4,7 @@ import { API_VERSION, HTTP_HOST, BUILD_NUMBER, FORCE_ERROR } from "../config";
 
 export const iframeController = (req: Request, res: Response) => {
   res.setHeader("Content-Type", "text/html");
-  res.setHeader("Cache-Control", "public, max-age=3600, s-maxage=300");
+  res.setHeader("Cache-Control", "public, max-age=3600, stale-while-revalidate");
 
   if (FORCE_ERROR) {
     res.sendStatus(500);

--- a/src/controller/iframe.ts
+++ b/src/controller/iframe.ts
@@ -4,7 +4,7 @@ import { API_VERSION, HTTP_HOST, BUILD_NUMBER, FORCE_ERROR } from "../config";
 
 export const iframeController = (req: Request, res: Response) => {
   res.setHeader("Content-Type", "text/html");
-  res.setHeader("Cache-Control", "public, max-age=3600, s-maxage=300, stale-while-revalidate");
+  res.setHeader("Cache-Control", "public, max-age=3600, s-maxage=3600, stale-while-revalidate");
 
   if (FORCE_ERROR) {
     res.sendStatus(500);

--- a/src/controller/iframe.ts
+++ b/src/controller/iframe.ts
@@ -1,10 +1,15 @@
 import { Request, Response } from "express";
 
-import { API_VERSION, HTTP_HOST, BUILD_NUMBER } from "../config";
+import { API_VERSION, HTTP_HOST, BUILD_NUMBER, FORCE_ERROR } from "../config";
 
 export const iframeController = (req: Request, res: Response) => {
   res.setHeader("Content-Type", "text/html");
   res.setHeader("Cache-Control", "public, max-age=3600, s-maxage=300");
+
+  if (FORCE_ERROR) {
+    res.sendStatus(500);
+    return;
+  }
 
   res.render("iframe.html", {
     VERSION_PATH: API_VERSION ? `/${API_VERSION}/` : "/",

--- a/src/controller/iframe.ts
+++ b/src/controller/iframe.ts
@@ -4,7 +4,7 @@ import { API_VERSION, HTTP_HOST, BUILD_NUMBER, FORCE_ERROR } from "../config";
 
 export const iframeController = (req: Request, res: Response) => {
   res.setHeader("Content-Type", "text/html");
-  res.setHeader("Cache-Control", "public, max-age=3600, stale-while-revalidate");
+  res.setHeader("Cache-Control", "public, max-age=3600, s-maxage=300, stale-while-revalidate");
 
   if (FORCE_ERROR) {
     res.sendStatus(500);


### PR DESCRIPTION
By setting `FORCE_ERROR` env var to `true`, the CMP scripts endpoints will always return a 500 error.