### PR TITLE
Polyfills for OIPF Release 1 DAE compliance

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -1,6 +1,7 @@
 import gulp from "gulp";
 import htmlmin from "gulp-htmlmin";
 import minifyInline from "gulp-minify-inline";
+import size from "gulp-size";
 import sourcemaps from "gulp-sourcemaps";
 import stringReplace from "gulp-string-replace";
 import terser from "gulp-terser";
@@ -61,4 +62,18 @@ function minifyHtmlTemplates() {
     .pipe(gulp.dest("./dist/templates"));
 }
 
-export default gulp.series(typescript, copyTemplates, setSourceHashParam, minifyJsTemplates, minifyHtmlTemplates);
+function printSize() {
+  return gulp
+    .src("./dist/templates/*")
+    .pipe(size({ showFiles: true }))
+    .pipe(gulp.dest("dist/templates"));
+}
+
+export default gulp.series(
+  typescript,
+  copyTemplates,
+  setSourceHashParam,
+  minifyJsTemplates,
+  minifyHtmlTemplates,
+  printSize,
+);

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "gulp": "^5.0.0",
     "gulp-htmlmin": "^5.0.1",
     "gulp-minify-inline": "^1.1.0",
+    "gulp-size": "^5.0.0",
     "gulp-sourcemaps": "^3.0.0",
     "gulp-string-replace": "^1.1.2",
     "gulp-terser": "^2.1.0",

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -3,5 +3,6 @@ export { cmpWithTrackingController } from "./cmpWithTracking";
 export { cmpController } from "./cmp";
 export { cmpapiController } from "./cmpapi";
 export { iframeController } from "./iframe";
+export { polyfillController } from "./polyfill";
 export { setConsentController } from "./setConsent";
 export { removeConsentController } from "./removeConsent";

--- a/src/controller/polyfill.ts
+++ b/src/controller/polyfill.ts
@@ -1,0 +1,13 @@
+import { Request, Response } from "express";
+import path from "path";
+
+export const polyfillController = async (_req: Request, res: Response) => {
+  res.setHeader("Content-Type", "application/javascript");
+  res.setHeader("Cache-Control", "public, max-age=3600, s-maxage=3600, stale-while-revalidate");
+
+  try {
+    res.sendFile(path.join(__dirname, "..", "templates", "polyfill.js"));
+  } catch (e) {
+    res.status(500).send(e);
+  }
+};

--- a/src/router.ts
+++ b/src/router.ts
@@ -10,6 +10,7 @@ import {
   removeConsentController,
   setConsentController,
   cmpapiController,
+  polyfillController,
 } from "./controller";
 
 import { loggerMiddleware, channelMiddleware } from "./middleware";
@@ -21,6 +22,7 @@ router.use(cookieParser());
 router.use(loggerMiddleware);
 router.use(channelMiddleware);
 
+router.get("/polyfill.js", polyfillController);
 router.get("/banner.js", bannerController);
 router.get("/cmp.js", cmpController);
 router.get("/cmp-with-tracking.js", cmpWithTrackingController);

--- a/src/templates/cmp.js
+++ b/src/templates/cmp.js
@@ -196,5 +196,18 @@
     }
   }
 
-  init();
+  waitForDOMElement(
+    'head',
+    function () {
+      var polyfillScriptTag = document.createElement('script');
+      polyfillScriptTag.setAttribute(
+        'src',
+        window.location.protocol + '//<%-CONSENT_SERVER_HOST%><%-VERSION_PATH%>polyfill.js'
+      );
+      polyfillScriptTag.setAttribute('type', 'text/javascript');
+      document.getElementsByTagName('head')[0].appendChild(polyfillScriptTag);
+      init();
+    },
+    3
+  );
 })();

--- a/src/templates/cmpapi.js
+++ b/src/templates/cmpapi.js
@@ -50,18 +50,10 @@
     }
   }
 
-  function objectKeys(obj) {
-    var keys = [];
-    for (var key in obj) {
-      keys.push(key);
-    }
-    return keys;
-  }
-
   function serializeConsentByVendorId(consentByVendorId) {
     var serialized = '';
     try {
-      var vendorIds = objectKeys(consentByVendorId);
+      var vendorIds = Object.keys(consentByVendorId);
       for (var i = 0; i < vendorIds.length; i++) {
         serialized = serialized + vendorIds[i] + '~' + consentByVendorId[vendorIds[i]];
         if (i < vendorIds.length - 1) {

--- a/src/templates/iframe.html
+++ b/src/templates/iframe.html
@@ -2,15 +2,16 @@
 <html xmlns='http://www.w3.org/1999/xhtml'>
 
 <head>
-  <meta http-equiv="content-type" content="application/vnd.hbbtv.xhtml+xml; charset=utf-8">
-  </meta>
-  <title></title>
+  <meta http-equiv="content-type" content="application/vnd.hbbtv.xhtml+xml; charset=utf-8" />
+  <script type='text/javascript' src='polyfill.js'></script>
   <script type='text/javascript'>
     //<![CDATA[
     function _message(msg) {
-      if (window.parent && window.parent.postMessage) {
-        window.parent.postMessage(msg, '*');
-      }
+      try {
+        if (window.parent && window.parent.postMessage) {
+          window.parent.postMessage(msg, '*');
+        }
+      } catch (e) {}
     }
 
     function messageEventHandler(event) {
@@ -41,20 +42,18 @@
       window.addEventListener('message', messageEventHandler, false);
     }
 
-    try {
-      var channelId = '<%-CHANNEL_ID%>';
-      var buildNumber = '<%-BUILD_NUMBER%>';
+    var channelId = '<%-CHANNEL_ID%>';
+    var buildNumber = '<%-BUILD_NUMBER%>';
 
-      var q = '';
-      q = q + (channelId !== '' ? '&channelId=' + channelId : '');
-      q = q + (buildNumber !== '' ? '&v=' + buildNumber : '');
-      q = q.length ? '?' + q.substring(1) : '';
+    var q = '';
+    q = q + (channelId !== '' ? '&channelId=' + channelId : '');
+    q = q + (buildNumber !== '' ? '&v=' + buildNumber : '');
+    q = q.length ? '?' + q.substring(1) : '';
 
-      var cmpApiScriptTag = document.createElement('script');
-      cmpApiScriptTag.setAttribute('src', window.location.protocol + '//<%-CONSENT_SERVER_HOST%><%-VERSION_PATH%>cmpapi.js' + q);
-      cmpApiScriptTag.setAttribute('type', 'text/javascript');
-      document.getElementsByTagName('head')[0].appendChild(cmpApiScriptTag);
-    } catch (e) { }
+    var cmpApiScriptTag = document.createElement('script');
+    cmpApiScriptTag.setAttribute('src', window.location.protocol + '//<%-CONSENT_SERVER_HOST%><%-VERSION_PATH%>cmpapi.js' + q);
+    cmpApiScriptTag.setAttribute('type', 'text/javascript');
+    document.getElementsByTagName('head')[0].appendChild(cmpApiScriptTag);
     //]]>
   </script>
 </head>

--- a/src/templates/polyfill.js
+++ b/src/templates/polyfill.js
@@ -1,0 +1,133 @@
+if (!window.Object.keys) {
+  window.Object.keys = (function () {
+    var hasOwnProperty = Object.prototype.hasOwnProperty,
+      hasDontEnumBug = !Object.prototype.propertyIsEnumerable.call({ toString: null }, 'toString'),
+      DontEnums = [
+        'toString',
+        'toLocaleString',
+        'valueOf',
+        'hasOwnProperty',
+        'isPrototypeOf',
+        'propertyIsEnumerable',
+        'constructor'
+      ],
+      DontEnumsLength = DontEnums.length;
+
+    return function (o) {
+      if ((typeof o != 'object' && typeof o != 'function') || o === null) {
+        throw new TypeError('Object.keys called on a non-object');
+      }
+
+      var result = [];
+      for (var name in o) {
+        if (hasOwnProperty.call(o, name)) result.push(name);
+      }
+
+      if (hasDontEnumBug) {
+        for (var i = 0; i < DontEnumsLength; i++) {
+          if (hasOwnProperty.call(o, DontEnums[i])) {
+            result.push(DontEnums[i]);
+          }
+        }
+      }
+
+      return result;
+    };
+  })();
+
+  console.log('Object.keys polyfill applied');
+}
+
+if (!window.atob) {
+  var chars = {
+    ascii: function () {
+      return 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
+    },
+    indices: function () {
+      if (!this.cache) {
+        this.cache = {};
+        var ascii = chars.ascii();
+
+        for (var c = 0; c < ascii.length; c++) {
+          var chr = ascii[c];
+          this.cache[chr] = c;
+        }
+      }
+      return this.cache;
+    }
+  };
+
+  window.atob = function (b64) {
+    var indices = chars.indices(),
+      pos = b64.indexOf('='),
+      padded = pos > -1,
+      len = padded ? pos : b64.length,
+      i = -1,
+      data = '';
+    while (i < len) {
+      var code = (indices[b64[++i]] << 18) | (indices[b64[++i]] << 12) | (indices[b64[++i]] << 6) | indices[b64[++i]];
+      if (code !== 0) {
+        data += String.fromCharCode((code >>> 16) & 255, (code >>> 8) & 255, code & 255);
+      }
+    }
+    if (padded) {
+      data = data.slice(0, pos - b64.length);
+    }
+    return data;
+  };
+
+  console.log('atob polyfill applied');
+}
+
+if (!window.JSON) {
+  window.JSON = {};
+}
+
+if (!window.JSON.parse) {
+  window.JSON.parse = function (jsonString) {
+    return eval('(' + jsonString + ')');
+  };
+
+  console.log('JSON.parse polyfill applied');
+}
+
+if (!window.JSON.stringify) {
+  window.JSON.stringify = function (object) {
+    var result = undefined;
+    if (object === null) {
+      return 'null';
+    } else if (object === undefined) {
+      return undefined;
+    } else if (typeof object === 'string') {
+      return '"' + object + '"';
+    } else if (typeof object === 'number' || typeof object === 'boolean') {
+      return object.toString();
+    } else if (Object.prototype.toString.call(object) === '[object Array]') {
+      result = '[';
+      for (var i = 0; i < object.length; i++) {
+        result += window.JSON.stringify(object[i]);
+        if (i !== object.length - 1) {
+          result += ',';
+        }
+      }
+      result += ']';
+      return result;
+    } else if (typeof object === 'object') {
+      result = '{';
+      var keys = Object.keys(object);
+      for (var y = 0; y < keys.length; y++) {
+        var key = keys[y];
+        result += '"' + key + '":' + window.JSON.stringify(object[key]);
+        if (y !== keys.length - 1) {
+          result += ',';
+        }
+      }
+      result += '}';
+      return result;
+    } else {
+      return undefined;
+    }
+  };
+
+  console.log('JSON.stringify polyfill applied');
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1059,7 +1059,7 @@
     "@types/node" "*"
     "@types/vinyl" "*"
 
-"@types/vinyl@*":
+"@types/vinyl@*", "@types/vinyl@^2.0.9":
   version "2.0.12"
   resolved "https://registry.yarnpkg.com/@types/vinyl/-/vinyl-2.0.12.tgz#17642ca9a8ae10f3db018e9f885da4188db4c6e6"
   integrity sha512-Sr2fYMBUVGYq8kj3UthXFAu5UN6ZW+rYr4NACjZQJvHvj+c8lYv0CahmZ2P/r7iUkN44gGUBwqxZkrKXYPb7cw==
@@ -1844,6 +1844,13 @@ brorand@^1.0.1, brorand@^1.1.0:
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
   integrity sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==
 
+brotli-size@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/brotli-size/-/brotli-size-4.0.0.tgz#a05ee3faad3c0e700a2f2da826ba6b4d76e69e5e"
+  integrity sha512-uA9fOtlTRC0iqKfzff1W34DXUA3GyVqbUaeo3Rw3d4gd1eavKVCETXrn3NzO74W+UVkG3UHu8WxUi+XvKI/huA==
+  dependencies:
+    duplexer "0.1.1"
+
 browser-pack@^6.0.1:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/browser-pack/-/browser-pack-6.1.0.tgz#c34ba10d0b9ce162b5af227c7131c92c2ecd5774"
@@ -2161,6 +2168,11 @@ chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.2:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+chalk@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.3.0.tgz#67c20a7ebef70e7f3970a01f90fa210cb6860385"
+  integrity sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==
 
 char-regex@^1.0.2:
   version "1.0.2"
@@ -3039,7 +3051,12 @@ duplexer2@^0.1.2, duplexer2@~0.1.0, duplexer2@~0.1.2:
   dependencies:
     readable-stream "^2.0.2"
 
-duplexer@~0.1.1:
+duplexer@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
+  integrity sha512-sxNZ+ljy+RA1maXoUReeqBBpBC6RLKmg5ewzV+x+mSETmWNoKdZN6vcQjpFROemza23hGFskJtFNoUWUaQ+R4Q==
+
+duplexer@^0.1.2, duplexer@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
   integrity sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==
@@ -3061,6 +3078,11 @@ each-props@^3.0.0:
   dependencies:
     is-plain-object "^5.0.0"
     object.defaults "^1.1.0"
+
+easy-transform-stream@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/easy-transform-stream/-/easy-transform-stream-1.0.1.tgz#faffdd1839a03d14d76e694bd2e6315551a6a215"
+  integrity sha512-ktkaa6XR7COAR3oj02CF3IOgz2m1hCaY3SfzvKT4Svt2MhHw9XCt+ncJNWfe2TGz31iqzNGZ8spdKQflj+Rlog==
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -3734,6 +3756,13 @@ fancy-log@^1.3.2:
     parse-node-version "^1.0.0"
     time-stamp "^1.0.0"
 
+fancy-log@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fancy-log/-/fancy-log-2.0.0.tgz#cad207b8396d69ae4796d74d17dff5f68b2f7343"
+  integrity sha512-9CzxZbACXMUXW13tS0tI8XsGGmxWzO2DmYrGuBJOJ8k8q2K7hwfJA5qHjuPPe8wtsco33YR9wc+Rlr5wYFvhSA==
+  dependencies:
+    color-support "^1.1.3"
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -4342,6 +4371,27 @@ gulp-minify-inline@^1.1.0:
     terser "^3.14.1"
     through2 "^3.0.0"
 
+gulp-plugin-extras@^0.2.1:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/gulp-plugin-extras/-/gulp-plugin-extras-0.2.2.tgz#8f4af2c0acdc95aaac9dcd86e54f200a6e2842c4"
+  integrity sha512-0gssXzTNrrOocYBWN4qOZqd03cz3bxhjxVUPZV9iJdBR0ZZbwMQO/OT8hZChYoc9GjKaA5meaqDr6CjkmKA7BA==
+  dependencies:
+    "@types/vinyl" "^2.0.9"
+    chalk "^5.3.0"
+    easy-transform-stream "^1.0.1"
+
+gulp-size@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/gulp-size/-/gulp-size-5.0.0.tgz#db78bf0290ca318f7a55abc3321ac4dbbeede9ea"
+  integrity sha512-iyyl9Dd1dHjXJnqxPfA5mZ5kPlaI+FRXklfXrfu/RoP3gHyT1n0IiEAHass5jvBCcBlatSx/JomkpTwnynyhkg==
+  dependencies:
+    brotli-size "^4.0.0"
+    chalk "^5.3.0"
+    fancy-log "^2.0.0"
+    gulp-plugin-extras "^0.2.1"
+    gzip-size "^7.0.0"
+    pretty-bytes "^6.1.1"
+
 gulp-sourcemaps@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/gulp-sourcemaps/-/gulp-sourcemaps-3.0.0.tgz#2e154e1a2efed033c0e48013969e6f30337b2743"
@@ -4409,6 +4459,13 @@ gulplog@^2.2.0:
   integrity sha512-V2FaKiOhpR3DRXZuYdRLn/qiY0yI5XmqbTKrYbdemJ+xOh2d2MOweI/XFgMzd/9+1twdvMwllnZbWZNJ+BOm4A==
   dependencies:
     glogg "^2.2.0"
+
+gzip-size@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-7.0.0.tgz#9f9644251f15bc78460fccef4055ae5a5562ac60"
+  integrity sha512-O1Ld7Dr+nqPnmGpdhzLmMTQ4vAsD+rHwMm1NLUmoUFFymBOMKxCCrtDxqdBRYXdeEPEi3SyoR4TizJLQrnKBNA==
+  dependencies:
+    duplexer "^0.1.2"
 
 has-bigints@^1.0.1, has-bigints@^1.0.2:
   version "1.0.2"
@@ -6731,6 +6788,11 @@ prettier@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.3.3.tgz#30c54fe0be0d8d12e6ae61dbb10109ea00d53105"
   integrity sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==
+
+pretty-bytes@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-6.1.1.tgz#38cd6bb46f47afbf667c202cfc754bffd2016a3b"
+  integrity sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==
 
 pretty-format@^29.0.0, pretty-format@^29.7.0:
   version "29.7.0"


### PR DESCRIPTION
According to the [OIPF Release 1 DAE Reference Guide](https://oipf.tv/docs/OIPF-T2-R1_DAE_Reference_Guide_v1_0-2010-03-11.pdf) the CMP uses some methods which are not supported by the HbbTV 1.0 Standard (atob, JSON.parse/stringify). While many manufacturer's browsers exceeded the specifications, and these methods are indeed available, we cannot be sure, as it is fully dependant on the used browser's capabilities.

In order to comply with the [OIPF Release 1 DAE Reference Guide](https://oipf.tv/docs/OIPF-T2-R1_DAE_Reference_Guide_v1_0-2010-03-11.pdf), this PR adds a separate `polyfill.js` for the unspecified methods. 